### PR TITLE
update erlang to 24.1.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         uses: erlef/setup-elixir@v1
         with:
           elixir-version: "1.12.3"
-          otp-version: "24.1.2"
+          otp-version: "24.1.4"
 
       - name: Restore dependencies cache
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.12.3-erlang-24.1.2-alpine-3.14.2 as build
+FROM hexpm/elixir:1.12.3-erlang-24.1.4-alpine-3.14.2 as build
 
 # install build dependencies
 RUN apk add --no-cache --update git build-base nodejs npm


### PR DESCRIPTION
example how to update erlang/elixir/alpine version, note that it's updated in two places, ci (to run tests on the relevant version combo) and in dockerfile (to actually update the version combo)

if alpine version is updated, it'd also be updated [in the final image](https://github.com/getsince/test3/blob/93f91d996961321712b7eaa761768728e2576021/Dockerfile#L39)