### PR TITLE
Since Live alpha

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -258,6 +258,7 @@ if config_env() == :test do
   config :t, T.PushNotifications.APNS, default_topic: "app.topic"
 
   config :t, T.Feeds.SeenPruner, disabled?: true
+  config :t, T.Feeds.LiveModeManager, disabled?: true
 end
 
 if config_env() == :bench do

--- a/dev/dev.ex
+++ b/dev/dev.ex
@@ -3,17 +3,8 @@ defmodule Dev do
     alert1_ru = %{
       "aps" => %{
         "alert" => %{
-          "title" => "Обнови приложение в App Store ✨",
-          "body" => "Текущая версия больше не поддерживается 🙃"
-        }
-      }
-    }
-
-    alert2_ru = %{
-      "aps" => %{
-        "alert" => %{
-          "title" => "В обновлении много важного 👉",
-          "body" => "Попробуй обмен контактами прямо из ленты 👀"
+          "title" => "Обнови приложение 👋",
+          "body" => "Встречай Since LIVE — новый формат вечеринки 🎉"
         }
       }
     }
@@ -21,17 +12,8 @@ defmodule Dev do
     alert1_en = %{
       "aps" => %{
         "alert" => %{
-          "title" => "Update the app in the App Store ✨",
-          "body" => "The current version is no longer supported 🙃"
-        }
-      }
-    }
-
-    alert2_en = %{
-      "aps" => %{
-        "alert" => %{
-          "title" => "Meet important things in the update 👉",
-          "body" => "Try sharing contacts straight from your feed 👀"
+          "title" => "Update the app 👋",
+          "body" => "Meet Since LIVE, a new party format 🎉"
         }
       }
     }
@@ -55,15 +37,12 @@ defmodule Dev do
       case locale do
         "ru" ->
           APNS.build_notification(device_id, topic, alert1_ru, env) |> APNS.push(T.Finch)
-          APNS.build_notification(device_id, topic, alert2_ru, env) |> APNS.push(T.Finch)
 
         "en" ->
           APNS.build_notification(device_id, topic, alert1_en, env) |> APNS.push(T.Finch)
-          APNS.build_notification(device_id, topic, alert2_en, env) |> APNS.push(T.Finch)
 
         _ ->
           APNS.build_notification(device_id, topic, alert1_ru, env) |> APNS.push(T.Finch)
-          APNS.build_notification(device_id, topic, alert2_ru, env) |> APNS.push(T.Finch)
       end
     end
   end

--- a/lib/t/accounts.ex
+++ b/lib/t/accounts.ex
@@ -338,6 +338,11 @@ defmodule T.Accounts do
     :ok
   end
 
+  @spec list_apns_devices() :: [%APNSDevice{}]
+  def list_apns_devices() do
+    APNSDevice |> Repo.all() |> with_base16_encoded_apns_device_id()
+  end
+
   @spec list_apns_devices(Ecto.UUID.t()) :: [%APNSDevice{}]
   def list_apns_devices(user_id) do
     APNSDevice

--- a/lib/t/application.ex
+++ b/lib/t/application.ex
@@ -28,6 +28,7 @@ defmodule T.Application do
         unless_disabled(T.Feeds.SeenPruner),
         unless_disabled(T.Matches.MatchExpirer),
         unless_disabled(T.PushNotifications.ScheduledPushes),
+        unless_disabled(T.Feeds.LiveModeManager),
         TWeb.Endpoint,
         TWeb.Telemetry,
         maybe_migrator(),

--- a/lib/t/calls.ex
+++ b/lib/t/calls.ex
@@ -256,8 +256,12 @@ defmodule T.Calls do
   defp maybe_after_missed_calls(query, after_id), do: where(query, [c], c.id > ^after_id)
 
   def list_live_missed_calls_with_profile(user_id, reference) do
-    missed_calls_q(user_id, [])
+    Call
+    |> where(called_id: ^user_id)
+    # call hasn't been picked up
+    |> where([c], is_nil(c.accepted_at))
     |> where([c], c.inserted_at > ^reference)
+    |> order_by(asc: :id)
     |> join(:inner, [c], p in FeedProfile, on: c.caller_id == p.user_id)
     |> select([c, p], {c, p})
     |> Repo.all()

--- a/lib/t/calls.ex
+++ b/lib/t/calls.ex
@@ -36,6 +36,7 @@ defmodule T.Calls do
 
       {:ok, call_id}
     else
+      # TODO error due to user being on another call
       {:allowed?, false} -> {:error, "call not allowed"}
       {:devices, []} -> {:error, "no pushkit devices available"}
       {:push, false} -> {:error, "all pushes failed"}

--- a/lib/t/calls.ex
+++ b/lib/t/calls.ex
@@ -44,6 +44,7 @@ defmodule T.Calls do
   end
 
   def call_allowed?(caller_id, called_id) do
+    # TODO or both live_session
     missed?(called_id, caller_id) or matched?(caller_id, called_id)
   end
 
@@ -237,4 +238,12 @@ defmodule T.Calls do
 
   defp maybe_after_missed_calls(query, nil), do: query
   defp maybe_after_missed_calls(query, after_id), do: where(query, [c], c.id > ^after_id)
+
+  def list_live_missed_calls_with_profile(user_id, reference) do
+    missed_calls_q(user_id, [])
+    |> where([c], c.inserted_at > ^reference)
+    |> join(:inner, [c], p in FeedProfile, on: c.caller_id == p.user_id)
+    |> select([c, p], {c, p})
+    |> Repo.all()
+  end
 end

--- a/lib/t/feeds.ex
+++ b/lib/t/feeds.ex
@@ -106,8 +106,10 @@ defmodule T.Feeds do
   # TODO change
   def since_live_time_text() do
     %{
-      "en" => "Come to Since Live every Thursday from 19:00 to 21:00, it will be great ✌️",
-      "ru" => "Приходи на Since Live каждый четверг с 19:00 до 21:00, будет классно ✌️"
+      "en" =>
+        "Come to Since Live every Thursday from 19:00 to 21:00 and Saturday from 20:00 to 22:00, it will be great ✌️",
+      "ru" =>
+        "Приходи на Since Live каждый четверг с 19:00 до 21:00 и субботу с 20:00 до 22:00, будет классно ✌️"
     }
   end
 
@@ -116,16 +118,27 @@ defmodule T.Feeds do
     hour = DateTime.utc_now().hour
     # minute = DateTime.utc_now().minute
 
-    # true
+    true
     # minute < 25
-    day_of_week == 4 && (hour == 16 || hour == 17)
+    # (day_of_week == 4 && (hour == 16 || hour == 17)) ||
+    # (day_of_week == 6 && (hour == 17 || hour == 18))
   end
 
   @spec live_mode_start_and_end_dates :: {DateTime.t(), DateTime.t()}
   def live_mode_start_and_end_dates() do
-    session_start = DateTime.new!(Date.utc_today(), Time.new!(18, 0, 0))
-    session_end = DateTime.new!(Date.utc_today(), Time.new!(16, 0, 0))
-    {session_start, session_end}
+    day_of_week = Date.utc_today() |> Date.day_of_week()
+
+    case day_of_week do
+      6 ->
+        session_start = DateTime.new!(Date.utc_today(), Time.new!(17, 0, 0))
+        session_end = DateTime.new!(Date.utc_today(), Time.new!(19, 0, 0))
+        {session_start, session_end}
+
+      _ ->
+        session_start = DateTime.new!(Date.utc_today(), Time.new!(16, 0, 0))
+        session_end = DateTime.new!(Date.utc_today(), Time.new!(18, 0, 0))
+        {session_start, session_end}
+    end
   end
 
   def notify_live_mode_start() do

--- a/lib/t/feeds.ex
+++ b/lib/t/feeds.ex
@@ -107,6 +107,14 @@ defmodule T.Feeds do
     end
   end
 
+  def notify_live_mode_will_be_today() do
+    DispatchJob.new(%{"type" => "live_mode_today"}) |> Oban.insert()
+  end
+
+  def notify_live_mode_soon() do
+    DispatchJob.new(%{"type" => "live_mode_soon"}) |> Oban.insert()
+  end
+
   def notify_live_mode_start() do
     m = "LIVE started"
     Logger.warn(m)

--- a/lib/t/feeds/live_invite.ex
+++ b/lib/t/feeds/live_invite.ex
@@ -9,8 +9,6 @@ defmodule T.Feeds.LiveInvite do
     belongs_to :by_user, User, primary_key: true
     belongs_to :user, User, primary_key: true
 
-    field :inviter_profile, :map, virtual: true
-
     timestamps(updated_at: false)
   end
 end

--- a/lib/t/feeds/live_invite.ex
+++ b/lib/t/feeds/live_invite.ex
@@ -1,0 +1,16 @@
+defmodule T.Feeds.LiveInvite do
+  @moduledoc false
+  use Ecto.Schema
+  alias T.Accounts.User
+
+  @primary_key false
+  @foreign_key_type Ecto.Bigflake.UUID
+  schema "live_invites" do
+    belongs_to :by_user, User, primary_key: true
+    belongs_to :user, User, primary_key: true
+
+    field :inviter_profile, :map, virtual: true
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/t/feeds/live_mode_manager.ex
+++ b/lib/t/feeds/live_mode_manager.ex
@@ -1,0 +1,38 @@
+defmodule T.Feeds.LiveModeManager do
+  @moduledoc """
+  Schedules live mode pushes: start & end; cleans live_sessions and live_invites after that
+  """
+
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    live_mode = opts[:live_mode] || false
+    check_interval = opts[:check_interval] || :timer.seconds(1)
+    :timer.send_interval(check_interval, :check_mode_change)
+    {:ok, %{live_mode: live_mode}}
+  end
+
+  @impl true
+  def handle_info(:check_mode_change, %{live_mode: previous_mode} = _state) do
+    current_mode = T.Feeds.is_now_live_mode()
+
+    case {previous_mode, current_mode} do
+      {false, true} ->
+        T.Feeds.notify_live_mode_start()
+
+      {true, false} ->
+        T.Feeds.notify_live_mode_end()
+        T.Feeds.clear_live_tables()
+
+      _ ->
+        nil
+    end
+
+    {:noreply, %{live_mode: current_mode}}
+  end
+end

--- a/lib/t/feeds/live_session.ex
+++ b/lib/t/feeds/live_session.ex
@@ -1,0 +1,10 @@
+defmodule T.Feeds.LiveSession do
+  use Ecto.Schema
+
+  @primary_key {:flake, Ecto.Bigflake.UUID, autogenerate: true}
+  @foreign_key_type Ecto.Bigflake.UUID
+  schema "live_sessions" do
+    belongs_to :user, T.Accounts.User, primary_key: true
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/t/matches.ex
+++ b/lib/t/matches.ex
@@ -8,7 +8,7 @@ defmodule T.Matches do
 
   alias T.Repo
   alias T.Matches.{Match, Like, Timeslot, MatchEvent, ExpiredMatch, MatchContact}
-  alias T.Feeds.FeedProfile
+  alias T.Feeds.{FeedProfile, LiveSession}
   alias T.Accounts.Profile
   alias T.PushNotifications.DispatchJob
   alias T.Bot
@@ -207,6 +207,23 @@ defmodule T.Matches do
       {:error, _step, _reason, _changes} = failure ->
         failure
     end
+  end
+
+  # - Live Matches
+
+  defp active_live_sessions() do
+    LiveSession |> select([s], s.user_id)
+  end
+
+  @spec list_live_matches(uuid) :: [%Match{}]
+  def list_live_matches(user_id) do
+    Match
+    |> where([m], m.user_id_1 == ^user_id or m.user_id_2 == ^user_id)
+    |> where([m], m.user_id_1 in subquery(active_live_sessions()))
+    |> where([m], m.user_id_2 in subquery(active_live_sessions()))
+    |> order_by(desc: :inserted_at)
+    |> Repo.all()
+    |> preload_match_profiles(user_id)
   end
 
   # - Matches

--- a/lib/t/matches.ex
+++ b/lib/t/matches.ex
@@ -226,6 +226,16 @@ defmodule T.Matches do
     |> preload_match_profiles(user_id)
   end
 
+  def is_match?(uid1, uid2) do
+    [user_id_1, user_id_2] = Enum.sort([uid1, uid2])
+
+    Match
+    |> where(user_id_1: ^user_id_1)
+    |> where(user_id_2: ^user_id_2)
+    |> select([m], m.id)
+    |> Repo.one()
+  end
+
   # - Matches
 
   @spec list_matches(uuid) :: [%Match{}]

--- a/lib/t/push_notifications/apns.ex
+++ b/lib/t/push_notifications/apns.ex
@@ -218,12 +218,11 @@ defmodule T.PushNotifications.APNS do
     gender_a = if gender == "F", do: "a", else: ""
 
     alert = %{
-      "title" =>
-        dgettext("apns", "Мэтч %{name} готов%{gender_a} общаться 👋",
-          name: name,
+      "title" => dgettext("apns", "Мэтч %{name} онлайн 👋", name: name),
+      "body" =>
+        dgettext("apns", "...и готов%{gender_a} общаться! Заходи и звони сейчас 👉",
           gender_a: gender_a
-        ),
-      "body" => dgettext("apns", "Заходи и звони сейчас 👉")
+        )
     }
 
     base_alert_payload(type, alert, %{"user_id" => user_id})
@@ -239,9 +238,17 @@ defmodule T.PushNotifications.APNS do
   end
 
   def build_alert_payload("live_mode_ended" = type, _data) do
+    day_of_week = Date.utc_today() |> Date.day_of_week()
+
+    body =
+      case day_of_week do
+        6 -> dgettext("apns", "Wait for the party on Thursday 👀")
+        _ -> dgettext("apns", "Wait for the party on Saturday 👀")
+      end
+
     alert = %{
       "title" => dgettext("apns", "Since Live ended ✌️"),
-      "body" => dgettext("apns", "Wait for the party in a week 👀")
+      "body" => body
     }
 
     base_alert_payload(type, alert, %{})

--- a/lib/t/push_notifications/apns.ex
+++ b/lib/t/push_notifications/apns.ex
@@ -211,6 +211,16 @@ defmodule T.PushNotifications.APNS do
     base_alert_payload(type, alert)
   end
 
+  def build_alert_payload("live_invite" = type, data) do
+    %{"user_id" => user_id, "name" => name} = data
+
+    alert = %{
+      "title" => dgettext("apns", "%{name} invited you to talk now during Since Live", name: name)
+    }
+
+    base_alert_payload(type, alert, %{"user_id" => user_id})
+  end
+
   # backround notifications
 
   def background_notification_payload(type, data) do

--- a/lib/t/push_notifications/apns.ex
+++ b/lib/t/push_notifications/apns.ex
@@ -97,12 +97,7 @@ defmodule T.PushNotifications.APNS do
   def build_alert_payload("timeslot_offer" = type, data) do
     %{"name" => name, "gender" => gender} = data
 
-    gender_a =
-      if(gender == "F") do
-        "a"
-      else
-        ""
-      end
+    gender_a = if gender == "F", do: "a", else: ""
 
     alert = %{
       "title" =>
@@ -183,12 +178,7 @@ defmodule T.PushNotifications.APNS do
   def build_alert_payload("contact_offer" = type, data) do
     %{"name" => name, "gender" => gender} = data
 
-    gender_a =
-      if(gender == "F") do
-        "a"
-      else
-        ""
-      end
+    gender_a = if gender == "F", do: "a", else: ""
 
     alert = %{
       "title" =>
@@ -215,10 +205,46 @@ defmodule T.PushNotifications.APNS do
     %{"user_id" => user_id, "name" => name} = data
 
     alert = %{
-      "title" => dgettext("apns", "%{name} invited you to talk now during Since Live", name: name)
+      "title" => dgettext("apns", "%{name} invites you to talk 👉", name: name),
+      "body" => dgettext("apns", "Call now, this is Since Live 🎉")
     }
 
     base_alert_payload(type, alert, %{"user_id" => user_id})
+  end
+
+  def build_alert_payload("match_went_live" = type, data) do
+    %{"user_id" => user_id, "name" => name, "gender" => gender} = data
+
+    gender_a = if gender == "F", do: "a", else: ""
+
+    alert = %{
+      "title" =>
+        dgettext("apns", "Мэтч %{name} готов%{gender_a} общаться 👋",
+          name: name,
+          gender_a: gender_a
+        ),
+      "body" => dgettext("apns", "Заходи и звони сейчас 👉")
+    }
+
+    base_alert_payload(type, alert, %{"user_id" => user_id})
+  end
+
+  def build_alert_payload("live_mode_started" = type, _data) do
+    alert = %{
+      "title" => dgettext("apns", "Since Live starts 🥳"),
+      "body" => dgettext("apns", "Come to the party and chat 🎉")
+    }
+
+    base_alert_payload(type, alert, %{})
+  end
+
+  def build_alert_payload("live_mode_ended" = type, _data) do
+    alert = %{
+      "title" => dgettext("apns", "Since Live ended ✌️"),
+      "body" => dgettext("apns", "Wait for the party in a week 👀")
+    }
+
+    base_alert_payload(type, alert, %{})
   end
 
   # backround notifications

--- a/lib/t/push_notifications/apns.ex
+++ b/lib/t/push_notifications/apns.ex
@@ -228,6 +228,32 @@ defmodule T.PushNotifications.APNS do
     base_alert_payload(type, alert, %{"user_id" => user_id})
   end
 
+  def build_alert_payload("live_mode_today" = type, _data) do
+    day_of_week = Date.utc_today() |> Date.day_of_week()
+
+    body =
+      case day_of_week do
+        6 -> dgettext("apns", "Come to the party at 20:00, it will be 🔥")
+        4 -> dgettext("apns", "Come to the party at 19:00, it will be 🔥")
+      end
+
+    alert = %{
+      "title" => dgettext("apns", "Since LIVE today 🥳"),
+      "body" => body
+    }
+
+    base_alert_payload(type, alert, %{})
+  end
+
+  def build_alert_payload("live_mode_soon" = type, _data) do
+    alert = %{
+      "title" => dgettext("apns", "Since LIVE starts soon 🔥"),
+      "body" => dgettext("apns", "Come chat with new people 🥳")
+    }
+
+    base_alert_payload(type, alert, %{})
+  end
+
   def build_alert_payload("live_mode_started" = type, _data) do
     alert = %{
       "title" => dgettext("apns", "Since Live starts 🥳"),
@@ -243,7 +269,7 @@ defmodule T.PushNotifications.APNS do
     body =
       case day_of_week do
         6 -> dgettext("apns", "Wait for the party on Thursday 👀")
-        _ -> dgettext("apns", "Wait for the party on Saturday 👀")
+        4 -> dgettext("apns", "Wait for the party on Saturday 👀")
       end
 
     alert = %{

--- a/lib/t/push_notifications/dispatch_job.ex
+++ b/lib/t/push_notifications/dispatch_job.ex
@@ -264,6 +264,23 @@ defmodule T.PushNotifications.DispatchJob do
     :ok
   end
 
+  defp handle_type("live_invite" = type, args) do
+    %{"by_user_id" => by_user_id, "user_id" => user_id} = args
+
+    if profile = profile_info(by_user_id) do
+      {name, _gender} = profile
+
+      data = %{
+        "user_id" => by_user_id,
+        "name" => name
+      }
+
+      user_id |> Accounts.list_apns_devices() |> schedule_apns(type, data)
+    end
+
+    :ok
+  end
+
   defp profile_info(user_id) do
     Accounts.Profile
     |> where(user_id: ^user_id)

--- a/lib/t/push_notifications/dispatch_job.ex
+++ b/lib/t/push_notifications/dispatch_job.ex
@@ -289,7 +289,8 @@ defmodule T.PushNotifications.DispatchJob do
     :ok
   end
 
-  defp handle_type(type, _args) when type in ["live_mode_started", "live_mode_ended"] do
+  defp handle_type(type, _args)
+       when type in ["live_mode_started", "live_mode_ended", "live_mode_today", "live_mode_soon"] do
     Accounts.list_apns_devices() |> schedule_apns(type, %{})
 
     :ok

--- a/lib/t/push_notifications/dispatch_job.ex
+++ b/lib/t/push_notifications/dispatch_job.ex
@@ -219,10 +219,7 @@ defmodule T.PushNotifications.DispatchJob do
     if profile = profile_info(by_user_id) do
       {name, _gender} = profile
 
-      data = %{
-        "user_id" => by_user_id,
-        "name" => name
-      }
+      data = %{"user_id" => by_user_id, "name" => name}
 
       user_id |> Accounts.list_apns_devices() |> schedule_apns(type, data)
     end
@@ -270,13 +267,30 @@ defmodule T.PushNotifications.DispatchJob do
     if profile = profile_info(by_user_id) do
       {name, _gender} = profile
 
-      data = %{
-        "user_id" => by_user_id,
-        "name" => name
-      }
+      data = %{"user_id" => by_user_id, "name" => name}
 
       user_id |> Accounts.list_apns_devices() |> schedule_apns(type, data)
     end
+
+    :ok
+  end
+
+  defp handle_type("match_went_live" = type, args) do
+    %{"for_user_id" => for_user_id, "user_id" => user_id} = args
+
+    if profile = profile_info(user_id) do
+      {name, gender} = profile
+
+      data = %{"user_id" => user_id, "name" => name, "gender" => gender}
+
+      for_user_id |> Accounts.list_apns_devices() |> schedule_apns(type, data)
+    end
+
+    :ok
+  end
+
+  defp handle_type(type, _args) when type in ["live_mode_started", "live_mode_ended"] do
+    Accounts.list_apns_devices() |> schedule_apns(type, %{})
 
     :ok
   end

--- a/lib/t_web/channels/user_socket.ex
+++ b/lib/t_web/channels/user_socket.ex
@@ -50,7 +50,7 @@ defmodule TWeb.UserSocket do
 
   defp check_version(nil), do: false
 
-  defp check_version(version), do: Version.match?(version, ">= 4.6.0")
+  defp check_version(version), do: Version.match?(version, ">= 4.7.0")
 
   def handle_error(conn, :unsupported_version),
     do: Plug.Conn.send_resp(conn, 418, "")

--- a/priv/gettext/apns.pot
+++ b/priv/gettext/apns.pot
@@ -130,27 +130,27 @@ msgid "Call now, this is Since Live 🎉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:234
+#: lib/t/push_notifications/apns.ex:260
 msgid "Come to the party and chat 🎉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:250
+#: lib/t/push_notifications/apns.ex:276
 msgid "Since Live ended ✌️"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:233
+#: lib/t/push_notifications/apns.ex:259
 msgid "Since Live starts 🥳"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:246
+#: lib/t/push_notifications/apns.ex:272
 msgid "Wait for the party on Saturday 👀"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:245
+#: lib/t/push_notifications/apns.ex:271
 msgid "Wait for the party on Thursday 👀"
 msgstr ""
 
@@ -162,4 +162,29 @@ msgstr ""
 #, elixir-format
 #: lib/t/push_notifications/apns.ex:221
 msgid "Мэтч %{name} онлайн 👋"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:251
+msgid "Come chat with new people 🥳"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:237
+msgid "Come to the party at 19:00, it will be 🔥"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:236
+msgid "Come to the party at 20:00, it will be 🔥"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:250
+msgid "Since LIVE starts soon 🔥"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:241
+msgid "Since LIVE today 🥳"
 msgstr ""

--- a/priv/gettext/apns.pot
+++ b/priv/gettext/apns.pot
@@ -11,22 +11,22 @@ msgid ""
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:113
+#: lib/t/push_notifications/apns.ex:108
 msgid "Заходи, чтобы ответить на приглашение 👀"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:146
+#: lib/t/push_notifications/apns.ex:141
 msgid "Попробуй предложить другое время 👉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:157
+#: lib/t/push_notifications/apns.ex:152
 msgid "Приготовься, у тебя 15 минут 👋"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:168
+#: lib/t/push_notifications/apns.ex:163
 msgid "Скорее заходи и звони 🖤"
 msgstr ""
 
@@ -51,12 +51,12 @@ msgid "Invite your match to a date if you want to keep it alive ✨"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:135
+#: lib/t/push_notifications/apns.ex:130
 msgid "Заходи и звони сейчас 👉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:109
+#: lib/t/push_notifications/apns.ex:104
 msgid "%{name} пригласил%{gender_a} тебя на дэйт!"
 msgstr ""
 
@@ -66,55 +66,100 @@ msgid "Match with %{name} is about to expire"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:167
+#: lib/t/push_notifications/apns.ex:162
 msgid "Аудио-дэйт с %{name} начинается"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:156
+#: lib/t/push_notifications/apns.ex:151
 msgid "Аудио-дэйт с %{name} совсем скоро"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:123 lib/t/push_notifications/apns.ex:134
+#: lib/t/push_notifications/apns.ex:118 lib/t/push_notifications/apns.ex:129
 msgid "Приглашение на дэйт c %{name} принято"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:145
+#: lib/t/push_notifications/apns.ex:140
 msgid "Твой дэйт с %{name} отменён"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:176
+#: lib/t/push_notifications/apns.ex:171
 msgid "Hey, create your own cool profile ✨"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:177
+#: lib/t/push_notifications/apns.ex:172
 msgid "Meet interesting people ✌️"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:124
+#: lib/t/push_notifications/apns.ex:119
 msgid "Аудио-дэйт уже в твоём календаре, не пропусти 👀"
 msgstr ""
 
-#: lib/t/push_notifications/apns.ex:195
+#: lib/t/push_notifications/apns.ex:185
 msgid "%{name} прислал%{gender_a} тебe контакт!"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:199
+#: lib/t/push_notifications/apns.ex:189
 msgid "Заходи, чтобы просмотреть и написать ✨"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:208
+#: lib/t/push_notifications/apns.ex:198
 msgid "The current version is no longer supported 🙃"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:207
+#: lib/t/push_notifications/apns.ex:197
 msgid "Update the app in the App Store ✨"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:208
+msgid "%{name} invites you to talk 👉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:209
+msgid "Call now, this is Since Live 🎉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:234
+msgid "Come to the party and chat 🎉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:250
+msgid "Since Live ended ✌️"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:233
+msgid "Since Live starts 🥳"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:246
+msgid "Wait for the party on Saturday 👀"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:245
+msgid "Wait for the party on Thursday 👀"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:223
+msgid "...и готов%{gender_a} общаться! Заходи и звони сейчас 👉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:221
+msgid "Мэтч %{name} онлайн 👋"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/apns.po
+++ b/priv/gettext/en/LC_MESSAGES/apns.po
@@ -12,22 +12,22 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:113
+#: lib/t/push_notifications/apns.ex:108
 msgid "Заходи, чтобы ответить на приглашение 👀"
 msgstr "Come in to respond to the invitation 👀"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:146
+#: lib/t/push_notifications/apns.ex:141
 msgid "Попробуй предложить другое время 👉"
 msgstr "Try suggesting a different time 👉"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:157
+#: lib/t/push_notifications/apns.ex:152
 msgid "Приготовься, у тебя 15 минут 👋"
 msgstr "Get ready, you have 15 minutes 👋"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:168
+#: lib/t/push_notifications/apns.ex:163
 msgid "Скорее заходи и звони 🖤"
 msgstr "Hurry up and start calling 🖤"
 
@@ -52,12 +52,12 @@ msgid "Invite your match to a date if you want to keep it alive ✨"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:135
+#: lib/t/push_notifications/apns.ex:130
 msgid "Заходи и звони сейчас 👉"
 msgstr "Come in and call now 👉"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:109
+#: lib/t/push_notifications/apns.ex:104
 msgid "%{name} пригласил%{gender_a} тебя на дэйт!"
 msgstr "%{name} invites you on a date!"
 
@@ -67,56 +67,100 @@ msgid "Match with %{name} is about to expire"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:167
+#: lib/t/push_notifications/apns.ex:162
 msgid "Аудио-дэйт с %{name} начинается"
 msgstr "Audio date with %{name} is starting"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:156
+#: lib/t/push_notifications/apns.ex:151
 msgid "Аудио-дэйт с %{name} совсем скоро"
 msgstr "Audio date with %{name} coming soon"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:123 lib/t/push_notifications/apns.ex:134
+#: lib/t/push_notifications/apns.ex:118 lib/t/push_notifications/apns.ex:129
 msgid "Приглашение на дэйт c %{name} принято"
 msgstr "%{name} has accepted invitation"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:145
+#: lib/t/push_notifications/apns.ex:140
 msgid "Твой дэйт с %{name} отменён"
 msgstr "%{name} has cancelled your date"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:176
+#: lib/t/push_notifications/apns.ex:171
 msgid "Hey, create your own cool profile ✨"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:177
+#: lib/t/push_notifications/apns.ex:172
 msgid "Meet interesting people ✌️"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:124
+#: lib/t/push_notifications/apns.ex:119
 msgid "Аудио-дэйт уже в твоём календаре, не пропусти 👀"
 msgstr "Audio-date is already in your calendar, don't miss it 👀"
 
-#, elixir-format, fuzzy
-#: lib/t/push_notifications/apns.ex:195
+#: lib/t/push_notifications/apns.ex:185
 msgid "%{name} прислал%{gender_a} тебe контакт!"
 msgstr "%{name} shared a contact with you!"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:199
+#: lib/t/push_notifications/apns.ex:189
 msgid "Заходи, чтобы просмотреть и написать ✨"
 msgstr "Come in to view & message ✨"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:208
+#: lib/t/push_notifications/apns.ex:198
 msgid "The current version is no longer supported 🙃"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:207
+#: lib/t/push_notifications/apns.ex:197
 msgid "Update the app in the App Store ✨"
 msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:208
+msgid "%{name} invites you to talk 👉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:209
+msgid "Call now, this is Since Live 🎉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:234
+msgid "Come to the party and chat 🎉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:250
+msgid "Since Live ended ✌️"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:233
+msgid "Since Live starts 🥳"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:246
+msgid "Wait for the party on Saturday 👀"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:245
+msgid "Wait for the party on Thursday 👀"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:223
+msgid "...и готов%{gender_a} общаться! Заходи и звони сейчас 👉"
+msgstr "...and ready for your call! Come in and call now 👉"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:221
+msgid "Мэтч %{name} онлайн 👋"
+msgstr "Match %{name} is online 👋"

--- a/priv/gettext/en/LC_MESSAGES/apns.po
+++ b/priv/gettext/en/LC_MESSAGES/apns.po
@@ -131,27 +131,27 @@ msgid "Call now, this is Since Live 🎉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:234
+#: lib/t/push_notifications/apns.ex:260
 msgid "Come to the party and chat 🎉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:250
+#: lib/t/push_notifications/apns.ex:276
 msgid "Since Live ended ✌️"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:233
+#: lib/t/push_notifications/apns.ex:259
 msgid "Since Live starts 🥳"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:246
+#: lib/t/push_notifications/apns.ex:272
 msgid "Wait for the party on Saturday 👀"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:245
+#: lib/t/push_notifications/apns.ex:271
 msgid "Wait for the party on Thursday 👀"
 msgstr ""
 
@@ -164,3 +164,28 @@ msgstr "...and ready for your call! Come in and call now 👉"
 #: lib/t/push_notifications/apns.ex:221
 msgid "Мэтч %{name} онлайн 👋"
 msgstr "Match %{name} is online 👋"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:251
+msgid "Come chat with new people 🥳"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:237
+msgid "Come to the party at 19:00, it will be 🔥"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:236
+msgid "Come to the party at 20:00, it will be 🔥"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/t/push_notifications/apns.ex:250
+msgid "Since LIVE starts soon 🔥"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:241
+msgid "Since LIVE today 🥳"
+msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/apns.po
+++ b/priv/gettext/ru/LC_MESSAGES/apns.po
@@ -131,27 +131,27 @@ msgid "Call now, this is Since Live 🎉"
 msgstr "Звони сейчас — это Since Live 🎉"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:234
+#: lib/t/push_notifications/apns.ex:260
 msgid "Come to the party and chat 🎉"
 msgstr "Заходи на вечеринку и общайся 🎉"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:250
+#: lib/t/push_notifications/apns.ex:276
 msgid "Since Live ended ✌️"
 msgstr "Since Live закончился ✌️"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:233
+#: lib/t/push_notifications/apns.ex:259
 msgid "Since Live starts 🥳"
 msgstr "Since Live начинается 🥳"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:246
+#: lib/t/push_notifications/apns.ex:272
 msgid "Wait for the party on Saturday 👀"
 msgstr "Жди следующую вечеринку в субботу 👀"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:245
+#: lib/t/push_notifications/apns.ex:271
 msgid "Wait for the party on Thursday 👀"
 msgstr "Жди следующую вечеринку в четверг 👀"
 
@@ -164,3 +164,28 @@ msgstr ""
 #: lib/t/push_notifications/apns.ex:221
 msgid "Мэтч %{name} онлайн 👋"
 msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:251
+msgid "Come chat with new people 🥳"
+msgstr "Приходи общаться с новыми людьми 🥳"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:237
+msgid "Come to the party at 19:00, it will be 🔥"
+msgstr "Приходи на вечеринку к 19:00, будет классно 🔥"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:236
+msgid "Come to the party at 20:00, it will be 🔥"
+msgstr "Приходи на вечеринку к 20:00, будет классно 🔥"
+
+#, elixir-format, fuzzy
+#: lib/t/push_notifications/apns.ex:250
+msgid "Since LIVE starts soon 🔥"
+msgstr "Since LIVE скоро начнется 🔥"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:241
+msgid "Since LIVE today 🥳"
+msgstr "Since LIVE уже сегодня 🥳"

--- a/priv/gettext/ru/LC_MESSAGES/apns.po
+++ b/priv/gettext/ru/LC_MESSAGES/apns.po
@@ -12,22 +12,22 @@ msgstr ""
 "Plural-Forms: nplurals=3\n"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:113
+#: lib/t/push_notifications/apns.ex:108
 msgid "Заходи, чтобы ответить на приглашение 👀"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:146
+#: lib/t/push_notifications/apns.ex:141
 msgid "Попробуй предложить другое время 👉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:157
+#: lib/t/push_notifications/apns.ex:152
 msgid "Приготовься, у тебя 15 минут 👋"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:168
+#: lib/t/push_notifications/apns.ex:163
 msgid "Скорее заходи и звони 🖤"
 msgstr ""
 
@@ -52,12 +52,12 @@ msgid "Invite your match to a date if you want to keep it alive ✨"
 msgstr "Пригласи на дэйт мэтча, если хочешь его сохранить ✨"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:135
+#: lib/t/push_notifications/apns.ex:130
 msgid "Заходи и звони сейчас 👉"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:109
+#: lib/t/push_notifications/apns.ex:104
 msgid "%{name} пригласил%{gender_a} тебя на дэйт!"
 msgstr ""
 
@@ -67,56 +67,100 @@ msgid "Match with %{name} is about to expire"
 msgstr "Мэтч c %{name} почти истек"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:167
+#: lib/t/push_notifications/apns.ex:162
 msgid "Аудио-дэйт с %{name} начинается"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:156
+#: lib/t/push_notifications/apns.ex:151
 msgid "Аудио-дэйт с %{name} совсем скоро"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:123 lib/t/push_notifications/apns.ex:134
+#: lib/t/push_notifications/apns.ex:118 lib/t/push_notifications/apns.ex:129
 msgid "Приглашение на дэйт c %{name} принято"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:145
+#: lib/t/push_notifications/apns.ex:140
 msgid "Твой дэйт с %{name} отменён"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:176
+#: lib/t/push_notifications/apns.ex:171
 msgid "Hey, create your own cool profile ✨"
 msgstr "Привет, создай свой классный профиль ✨"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:177
+#: lib/t/push_notifications/apns.ex:172
 msgid "Meet interesting people ✌️"
 msgstr "Знакомься с интересными людьми ✌️"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:124
+#: lib/t/push_notifications/apns.ex:119
 msgid "Аудио-дэйт уже в твоём календаре, не пропусти 👀"
 msgstr ""
 
-#, elixir-format, fuzzy
-#: lib/t/push_notifications/apns.ex:195
+#: lib/t/push_notifications/apns.ex:185
 msgid "%{name} прислал%{gender_a} тебe контакт!"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:199
+#: lib/t/push_notifications/apns.ex:189
 msgid "Заходи, чтобы просмотреть и написать ✨"
 msgstr ""
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:208
+#: lib/t/push_notifications/apns.ex:198
 msgid "The current version is no longer supported 🙃"
 msgstr "Текущая версия больше не поддерживается 🙃"
 
 #, elixir-format
-#: lib/t/push_notifications/apns.ex:207
+#: lib/t/push_notifications/apns.ex:197
 msgid "Update the app in the App Store ✨"
 msgstr "Обнови приложение в App Store ✨"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:208
+msgid "%{name} invites you to talk 👉"
+msgstr "%{name} приглашает тебя поговорить 👉"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:209
+msgid "Call now, this is Since Live 🎉"
+msgstr "Звони сейчас — это Since Live 🎉"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:234
+msgid "Come to the party and chat 🎉"
+msgstr "Заходи на вечеринку и общайся 🎉"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:250
+msgid "Since Live ended ✌️"
+msgstr "Since Live закончился ✌️"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:233
+msgid "Since Live starts 🥳"
+msgstr "Since Live начинается 🥳"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:246
+msgid "Wait for the party on Saturday 👀"
+msgstr "Жди следующую вечеринку в субботу 👀"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:245
+msgid "Wait for the party on Thursday 👀"
+msgstr "Жди следующую вечеринку в четверг 👀"
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:223
+msgid "...и готов%{gender_a} общаться! Заходи и звони сейчас 👉"
+msgstr ""
+
+#, elixir-format
+#: lib/t/push_notifications/apns.ex:221
+msgid "Мэтч %{name} онлайн 👋"
+msgstr ""

--- a/priv/repo/migrations/20211206172231_add_live_sessions.exs
+++ b/priv/repo/migrations/20211206172231_add_live_sessions.exs
@@ -1,0 +1,16 @@
+defmodule T.Repo.Migrations.AddLiveSessions do
+  use Ecto.Migration
+
+    def change do
+      create table(:live_sessions, primary_key: false) do
+        add :flake, :uuid, null: false
+        add :user_id, references(:users, on_delete: :delete_all, type: :uuid), primary_key: true
+        timestamps(updated_at: false)
+      end
+
+      create unique_index(:live_sessions, ["flake asc"])
+
+      drop table("call_invites")
+      drop table("active_sessions")
+    end
+end

--- a/priv/repo/migrations/20211206172231_add_live_sessions.exs
+++ b/priv/repo/migrations/20211206172231_add_live_sessions.exs
@@ -1,16 +1,16 @@
 defmodule T.Repo.Migrations.AddLiveSessions do
   use Ecto.Migration
 
-    def change do
-      create table(:live_sessions, primary_key: false) do
-        add :flake, :uuid, null: false
-        add :user_id, references(:users, on_delete: :delete_all, type: :uuid), primary_key: true
-        timestamps(updated_at: false)
-      end
-
-      create unique_index(:live_sessions, ["flake asc"])
-
-      drop table("call_invites")
-      drop table("active_sessions")
+  def change do
+    create table(:live_sessions, primary_key: false) do
+      add :flake, :uuid, null: false
+      add :user_id, references(:users, on_delete: :delete_all, type: :uuid), primary_key: true
+      timestamps(updated_at: false)
     end
+
+    create unique_index(:live_sessions, ["flake asc"])
+
+    drop table("call_invites")
+    drop table("active_sessions")
+  end
 end

--- a/priv/repo/migrations/20211207155835_add_live_invites.exs
+++ b/priv/repo/migrations/20211207155835_add_live_invites.exs
@@ -1,0 +1,17 @@
+defmodule T.Repo.Migrations.AddLiveInvites do
+  use Ecto.Migration
+
+  # TODO add flake
+  # TODO unqie index flake asc
+
+  @opts [on_delete: :delete_all, column: :user_id, type: :uuid]
+
+  def change do
+    create table(:live_invites, primary_key: false) do
+      add :by_user_id, references(:live_sessions, @opts), primary_key: true
+      add :user_id, references(:live_sessions, @opts), primary_key: true
+
+      timestamps(updated_at: false)
+    end
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -63,7 +63,7 @@ defmodule TWeb.ChannelCase do
       |> Accounts.generate_user_session_token("mobile")
       |> Accounts.UserToken.encoded_token()
 
-    {:ok, socket} = connect(TWeb.UserSocket, %{"token" => token, "version" => "4.6.0"}, %{})
+    {:ok, socket} = connect(TWeb.UserSocket, %{"token" => token, "version" => "4.7.0"}, %{})
     socket
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,7 +1,7 @@
 defmodule T.Factory do
   use ExMachina.Ecto, repo: T.Repo
   alias T.Accounts.{User, Profile, GenderPreference}
-  alias T.Feeds.SeenProfile
+  alias T.Feeds.{SeenProfile, LiveSession, LiveInvite}
   alias T.Matches.{Match, Timeslot, ExpiredMatch, MatchEvent, MatchContact}
   alias T.Calls.Call
 
@@ -51,6 +51,14 @@ defmodule T.Factory do
 
   def match_contact_factory do
     %MatchContact{}
+  end
+
+  def live_session_factory do
+    %LiveSession{}
+  end
+
+  def live_invites_factory do
+    %LiveInvite{}
   end
 
   def apple_id do

--- a/test/t/feeds/feeds_live_test.exs
+++ b/test/t/feeds/feeds_live_test.exs
@@ -1,0 +1,143 @@
+defmodule T.FeedsLiveTest do
+  use T.DataCase, async: true
+  use Oban.Testing, repo: T.Repo
+
+  alias T.Feeds
+  alias T.Feeds.{LiveSession, LiveInvite}
+  alias T.Accounts
+
+  describe "is_now_live_mode/2" do
+    test "Thursday" do
+      assert Feeds.is_now_live_mode(Date.new!(2021, 12, 9), Time.new!(17, 0, 0)) == true
+      assert Feeds.is_now_live_mode(Date.new!(2021, 12, 9), Time.new!(18, 0, 0)) == false
+    end
+
+    test "Saturday" do
+      assert Feeds.is_now_live_mode(Date.new!(2021, 12, 11), Time.new!(17, 0, 0)) == true
+      assert Feeds.is_now_live_mode(Date.new!(2021, 12, 11), Time.new!(19, 0, 0)) == false
+    end
+
+    test "Monday" do
+      assert Feeds.is_now_live_mode(Date.new!(2021, 12, 6), Time.new!(17, 0, 0)) == false
+      assert Feeds.is_now_live_mode(Date.new!(2021, 12, 6), Time.new!(18, 0, 0)) == false
+    end
+  end
+
+  describe "maybe_activate_session/1" do
+    setup do
+      me = onboarded_user(location: moscow_location())
+      {:ok, me: me}
+    end
+
+    test "side-effects", %{me: me} do
+      Feeds.maybe_activate_session(me.id)
+      assert LiveSession |> select([s], s.user_id) |> Repo.all() == [me.id]
+    end
+
+    test "match is notified properly" do
+      [p1, p2] = insert_list(2, :profile, hidden?: false)
+
+      insert(:match, user_id_1: p1.user_id, user_id_2: p2.user_id)
+
+      Feeds.maybe_activate_session(p1.user_id)
+
+      assert [
+               %Oban.Job{
+                 args: %{
+                   "type" => "match_went_live",
+                   "user_id" => uid1,
+                   "for_user_id" => uid2
+                 }
+               }
+             ] = all_enqueued(worker: T.PushNotifications.DispatchJob)
+
+      assert uid1 == p1.user_id
+      assert uid2 == p2.user_id
+
+      Feeds.maybe_activate_session(p1.user_id)
+
+      assert length(all_enqueued(worker: T.PushNotifications.DispatchJob)) == 1
+    end
+  end
+
+  describe "fetch_live_feed/3" do
+    test "normal" do
+      [p1, p2, p3] = insert_list(3, :profile, hidden?: false)
+
+      ls1 = Feeds.maybe_activate_session(p1.user_id)
+      assert Feeds.fetch_live_feed(p1.user_id, 10, nil) == {[], nil}
+
+      ls2 = Feeds.maybe_activate_session(p2.user_id)
+      assert {[feed_profile], cursor} = Feeds.fetch_live_feed(p2.user_id, 10, nil)
+      assert feed_profile.user_id == p1.user_id
+      assert cursor == ls1.flake
+
+      _ls3 = Feeds.maybe_activate_session(p3.user_id)
+      assert {[fp1, fp2], cursor} = Feeds.fetch_live_feed(p3.user_id, 10, nil)
+      assert fp1.user_id == p1.user_id
+      assert fp2.user_id == p2.user_id
+      assert cursor == ls2.flake
+
+      assert Feeds.fetch_live_feed(p3.user_id, 10, cursor) == {[], cursor}
+    end
+  end
+
+  describe "live_invite_user/2" do
+    setup do
+      [p1, p2] = insert_list(2, :profile, hidden?: false)
+      p3 = insert(:profile, hidden?: true)
+      {:ok, profiles: [p1, p2, p3]}
+    end
+
+    test "with side-effects", %{profiles: [p1, p2, _p3]} do
+      assert_raise Ecto.ConstraintError, fn -> Feeds.live_invite_user(p1.user_id, p2.user_id) end
+
+      _ls1 = Feeds.maybe_activate_session(p1.user_id)
+      _ls2 = Feeds.maybe_activate_session(p2.user_id)
+
+      :ok = Feeds.subscribe_for_user(p2.user_id)
+
+      Feeds.live_invite_user(p1.user_id, p2.user_id)
+
+      assert LiveInvite |> select([s], {s.by_user_id, s.user_id}) |> Repo.all() == [
+               {p1.user_id, p2.user_id}
+             ]
+
+      assert_receive {Feeds, :live_invited, %{by_user_id: by_user_id}}
+      assert by_user_id == p1.user_id
+
+      assert [
+               %Oban.Job{
+                 args: %{
+                   "type" => "live_invite",
+                   "by_user_id" => by_user_id,
+                   "user_id" => user_id
+                 }
+               }
+             ] = all_enqueued(worker: T.PushNotifications.DispatchJob)
+
+      assert by_user_id == p1.user_id
+      assert user_id == p2.user_id
+    end
+
+    test "by reported user", %{profiles: [p1, p2, _p3]} do
+      _ls1 = Feeds.maybe_activate_session(p1.user_id)
+      _ls2 = Feeds.maybe_activate_session(p2.user_id)
+
+      Accounts.report_user(p2.user_id, p1.user_id, "default")
+
+      Feeds.live_invite_user(p1.user_id, p2.user_id)
+
+      assert LiveInvite |> Repo.all() == []
+    end
+
+    test "by hidden user", %{profiles: [p1, _p2, p3]} do
+      _ls1 = Feeds.maybe_activate_session(p1.user_id)
+      _ls3 = Feeds.maybe_activate_session(p3.user_id)
+
+      Feeds.live_invite_user(p3.user_id, p1.user_id)
+
+      assert LiveInvite |> Repo.all() == []
+    end
+  end
+end

--- a/test/t_web/channels/feed_channel_live_test.exs
+++ b/test/t_web/channels/feed_channel_live_test.exs
@@ -1,0 +1,463 @@
+defmodule TWeb.FeedChanneLiveTest do
+  use TWeb.ChannelCase, async: true
+
+  alias T.{Accounts, Calls, Matches, Feeds}
+  alias Matches.Match
+  alias Calls.Call
+
+  import Mox
+  setup :verify_on_exit!
+
+  setup do
+    me = onboarded_user(location: moscow_location(), accept_genders: ["F", "N", "M"])
+    {:ok, me: me, socket: connected_socket(me)}
+  end
+
+  describe "join" do
+    test "with matches", %{socket: socket, me: me} do
+      [p1, p2, p3] = [
+        onboarded_user(story: [], name: "mate-1", location: apple_location(), gender: "F"),
+        onboarded_user(story: [], name: "mate-2", location: apple_location(), gender: "N"),
+        onboarded_user(story: [], name: "mate-3", location: apple_location(), gender: "M")
+      ]
+
+      [m1, m2, _m3] = [
+        insert(:match, user_id_1: me.id, user_id_2: p1.id, inserted_at: ~N[2021-09-30 12:16:05]),
+        insert(:match, user_id_1: me.id, user_id_2: p2.id, inserted_at: ~N[2021-09-30 12:16:06]),
+        insert(:match, user_id_1: me.id, user_id_2: p3.id, inserted_at: ~N[2021-09-30 12:16:07])
+      ]
+
+      joined_mate(%{mate: p1})
+      joined_mate(%{mate: p2})
+
+      assert {:ok, %{"matches" => matches}, _socket} =
+               join(socket, "feed:" <> me.id, %{"mode" => "live"})
+
+      assert matches == [
+               %{
+                 "id" => m2.id,
+                 "profile" => %{name: "mate-2", story: [], user_id: p2.id, gender: "N"}
+               },
+               %{
+                 "id" => m1.id,
+                 "profile" => %{name: "mate-1", story: [], user_id: p1.id, gender: "F"}
+               }
+             ]
+    end
+
+    test "with invites", %{socket: socket, me: me} do
+      mate = onboarded_user(story: [], name: "mate", location: apple_location(), gender: "F")
+
+      joined_mate(%{mate: mate})
+      assert {:ok, _reply, _socket} = join(socket, "feed:" <> me.id, %{"mode" => "live"})
+
+      Feeds.live_invite_user(mate.id, me.id)
+
+      assert {:ok, reply, _socket} = join(socket, "feed:" <> me.id, %{"mode" => "live"})
+      expiration_date = session_expiration_date()
+
+      assert reply == %{
+               "mode" => "live",
+               "session_expiration_date" => expiration_date,
+               "live_session_duration" => 7200,
+               "invites" => [
+                 %{
+                   "profile" => %{
+                     name: "mate",
+                     story: [],
+                     user_id: mate.id,
+                     gender: "F"
+                   }
+                 }
+               ]
+             }
+    end
+
+    test "with missed calls", %{socket: socket, me: me} do
+      "user_socket:" <> token = socket.id
+      mate = onboarded_user(story: [], location: apple_location(), name: "mate", gender: "F")
+
+      # prepare pushkit devices
+      :ok = Accounts.save_pushkit_device_id(me.id, token, Base.decode16!("ABABAB"), env: "prod")
+
+      # prepare apns mock
+      expect(MockAPNS, :push, 1, fn _notification -> :ok end)
+
+      _match = insert(:match, user_id_1: me.id, user_id_2: mate.id)
+
+      # mate calls me
+      {:ok, call_id2} = Calls.call(mate.id, me.id)
+      # mate ends call, so call_id2, should be considered missed
+      :ok = Calls.end_call(mate.id, call_id2)
+      %Call{} = c2 = Repo.get(Call, call_id2)
+      assert c2.ended_at
+      assert c2.ended_by == mate.id
+
+      assert {:ok, reply, _socket} = join(socket, "feed:" <> me.id, %{"mode" => "live"})
+
+      expiration_date = session_expiration_date()
+
+      assert reply == %{
+               "mode" => "live",
+               "session_expiration_date" => expiration_date,
+               "live_session_duration" => 7200,
+               "missed_calls" => [
+                 %{
+                   "call" => %{
+                     "id" => call_id2,
+                     "started_at" => DateTime.from_naive!(c2.inserted_at, "Etc/UTC"),
+                     "ended_at" => DateTime.from_naive!(c2.ended_at, "Etc/UTC")
+                   },
+                   "profile" => %{name: "mate", story: [], user_id: mate.id, gender: "F"}
+                 }
+               ]
+             }
+    end
+  end
+
+  describe "more" do
+    setup :joined
+
+    test "with no data in db", %{socket: socket} do
+      ref = push(socket, "more")
+      assert_reply(ref, :ok, reply)
+      assert reply == %{"cursor" => nil, "feed" => []}
+    end
+
+    test "with active users more than count", %{socket: socket} do
+      now = DateTime.utc_now()
+
+      [m1, m2, m3] = [
+        onboarded_user(
+          name: "mate-1",
+          location: apple_location(),
+          story: [%{"background" => %{"s3_key" => "test"}, "labels" => []}],
+          gender: "F",
+          accept_genders: ["M"],
+          last_active: DateTime.add(now, -1),
+          like_ratio: 1.0
+        ),
+        onboarded_user(
+          name: "mate-2",
+          location: apple_location(),
+          story: [%{"background" => %{"s3_key" => "test"}, "labels" => []}],
+          gender: "N",
+          accept_genders: ["M"],
+          last_active: DateTime.add(now, -2),
+          like_ratio: 0.5
+        ),
+        onboarded_user(
+          name: "mate-3",
+          location: apple_location(),
+          story: [%{"background" => %{"s3_key" => "test"}, "labels" => []}],
+          gender: "M",
+          accept_genders: ["M"],
+          last_active: DateTime.add(now, -3),
+          like_ratio: 0
+        )
+      ]
+
+      joined_mate(%{mate: m1})
+      joined_mate(%{mate: m2})
+      joined_mate(%{mate: m3})
+
+      ref = push(socket, "more", %{"count" => 2})
+      assert_reply(ref, :ok, %{"cursor" => cursor, "feed" => feed})
+
+      assert feed == [
+               %{
+                 "profile" => %{
+                   user_id: m1.id,
+                   name: "mate-1",
+                   gender: "F",
+                   story: [
+                     %{
+                       "background" => %{
+                         "proxy" =>
+                           "https://d1234.cloudfront.net/1hPLj5rf4QOwpxjzZB_S-X9SsrQMj0cayJcOCmnvXz4/fit/1000/0/sm/0/aHR0cHM6Ly9wcmV0ZW5kLXRoaXMtaXMtcmVhbC5zMy5hbWF6b25hd3MuY29tL3Rlc3Q",
+                         "s3_key" => "test"
+                       },
+                       "labels" => []
+                     }
+                   ]
+                 }
+               },
+               %{
+                 "profile" => %{
+                   user_id: m2.id,
+                   name: "mate-2",
+                   gender: "N",
+                   story: [
+                     %{
+                       "background" => %{
+                         "proxy" =>
+                           "https://d1234.cloudfront.net/1hPLj5rf4QOwpxjzZB_S-X9SsrQMj0cayJcOCmnvXz4/fit/1000/0/sm/0/aHR0cHM6Ly9wcmV0ZW5kLXRoaXMtaXMtcmVhbC5zMy5hbWF6b25hd3MuY29tL3Rlc3Q",
+                         "s3_key" => "test"
+                       },
+                       "labels" => []
+                     }
+                   ]
+                 }
+               }
+             ]
+
+      ref = push(socket, "more", %{"cursor" => cursor})
+
+      assert_reply(ref, :ok, %{
+        "cursor" => cursor,
+        "feed" => feed
+      })
+
+      assert feed == [
+               %{
+                 "profile" => %{
+                   user_id: m3.id,
+                   name: "mate-3",
+                   gender: "M",
+                   story: [
+                     %{
+                       "background" => %{
+                         "proxy" =>
+                           "https://d1234.cloudfront.net/1hPLj5rf4QOwpxjzZB_S-X9SsrQMj0cayJcOCmnvXz4/fit/1000/0/sm/0/aHR0cHM6Ly9wcmV0ZW5kLXRoaXMtaXMtcmVhbC5zMy5hbWF6b25hd3MuY29tL3Rlc3Q",
+                         "s3_key" => "test"
+                       },
+                       "labels" => []
+                     }
+                   ]
+                 }
+               }
+             ]
+
+      ref = push(socket, "more", %{"cursor" => cursor})
+      assert_reply(ref, :ok, %{"cursor" => ^cursor, "feed" => []})
+    end
+
+    test "seen profiles are returned in feed", %{socket: socket, me: me} do
+      mate =
+        onboarded_user(
+          name: "mate",
+          location: apple_location(),
+          story: [%{"background" => %{"s3_key" => "test"}, "labels" => []}],
+          gender: "M",
+          accept_genders: ["M"]
+        )
+
+      joined_mate(%{mate: mate})
+
+      T.Repo.insert(%T.Feeds.SeenProfile{by_user_id: me.id, user_id: mate.id})
+
+      ref = push(socket, "more", %{"count" => 5})
+      assert_reply(ref, :ok, %{"cursor" => _cursor, "feed" => feed})
+      assert length(feed) == 1
+    end
+  end
+
+  describe "live-invite" do
+    setup :joined
+
+    setup do
+      {:ok, mate: onboarded_user(story: [], location: apple_location(), name: "mate")}
+    end
+
+    setup :joined_mate
+
+    test "normal", %{
+      me: me,
+      mate: mate,
+      mate_socket: mate_socket
+    } do
+      # mate likes us
+      ref = push(mate_socket, "live-invite", %{"user_id" => me.id})
+      assert_reply(ref, :ok, reply)
+      assert reply == %{}
+
+      # we got notified of like
+      assert_push("live_invite", invite)
+
+      assert invite == %{
+               "profile" => %{
+                 gender: "M",
+                 name: "mate",
+                 story: [],
+                 user_id: mate.id
+               }
+             }
+    end
+  end
+
+  describe "successful calls to active mate" do
+    setup [:joined]
+
+    setup do
+      {:ok, mate: onboarded_user(story: [], location: apple_location(), name: "mate")}
+    end
+
+    setup :joined_mate
+
+    setup %{mate: mate, mate_socket: mate_socket} do
+      "user_socket:" <> mate_token = mate_socket.id
+
+      :ok =
+        Accounts.save_pushkit_device_id(
+          mate.id,
+          mate_token,
+          Base.decode16!("ABABABAB"),
+          env: "prod"
+        )
+
+      :ok =
+        Accounts.save_pushkit_device_id(
+          mate.id,
+          mate
+          |> Accounts.generate_user_session_token("mobile")
+          |> Accounts.UserToken.encoded_token(),
+          Base.decode16!("BABABABABA"),
+          env: "sandbox"
+        )
+    end
+
+    test "when non-matched with mate", %{me: me, mate: mate, socket: socket} do
+      # these are the pushes sent to mate
+      MockAPNS
+      # ABABABAB on prod -> success!
+      |> expect(:push, fn %{env: :prod} -> :ok end)
+      # BABABABABA on sandbox -> fails!
+      |> expect(:push, fn %{env: :dev} -> {:error, :bad_device_token} end)
+
+      ref = push(socket, "call", %{"user_id" => mate.id})
+      assert_reply(ref, :ok, %{"call_id" => call_id})
+
+      assert %Call{id: ^call_id} = call = Repo.get!(Calls.Call, call_id)
+
+      refute call.ended_at
+      refute call.accepted_at
+      assert call.caller_id == me.id
+      assert call.called_id == mate.id
+    end
+  end
+
+  describe "unmatch success" do
+    setup :joined
+
+    setup do
+      {:ok, mate: onboarded_user(story: [], location: apple_location(), name: "mate")}
+    end
+
+    setup :joined_mate
+
+    # match
+    setup %{me: me, socket: socket, mate: mate, mate_socket: mate_socket} do
+      # mate likes us
+      ref = push(mate_socket, "like", %{"user_id" => me.id})
+      assert_reply(ref, :ok, reply)
+      assert reply == %{}
+
+      # now it's our turn
+      ref = push(socket, "like", %{"user_id" => mate.id})
+      assert_reply(ref, :ok, %{"match_id" => match_id})
+
+      {:ok, match_id: match_id}
+    end
+
+    test "with match_id", %{socket: socket, match_id: match_id} do
+      ref = push(socket, "unmatch", %{"match_id" => match_id})
+      assert_reply(ref, :ok, %{"unmatched?" => true})
+
+      # mate gets unmatched message
+      assert_push("unmatched", push)
+      assert push == %{"match_id" => match_id}
+
+      refute Repo.get(Match, match_id)
+    end
+
+    test "with user_id", %{socket: socket, mate: mate, match_id: match_id} do
+      ref = push(socket, "unmatch", %{"user_id" => mate.id})
+      assert_reply(ref, :ok, %{"unmatched?" => true})
+
+      # mate gets unmatched message
+      assert_push("unmatched", push)
+      assert push == %{"match_id" => match_id}
+
+      refute Repo.get(Match, match_id)
+    end
+  end
+
+  describe "report without match" do
+    setup :joined
+
+    setup do
+      {:ok, mate: onboarded_user(story: [], location: apple_location(), name: "mate")}
+    end
+
+    setup :joined_mate
+
+    test "reports mate", %{socket: socket, mate: mate, me: me} do
+      ref =
+        push(socket, "report", %{
+          "user_id" => mate.id,
+          "reason" => "he don't believe in jesus"
+        })
+
+      assert_reply(ref, :ok, _reply)
+
+      assert %Accounts.UserReport{} =
+               report = Repo.get_by(Accounts.UserReport, from_user_id: me.id, on_user_id: mate.id)
+
+      assert report.reason == "he don't believe in jesus"
+    end
+  end
+
+  describe "report with match" do
+    setup :joined
+
+    setup %{me: me} do
+      mate = onboarded_user(story: [], location: apple_location(), name: "mate")
+      match = insert(:match, user_id_1: me.id, user_id_2: mate.id)
+      {:ok, mate: mate, match: match}
+    end
+
+    setup :joined_mate
+
+    test "reports mate and notifies of unmatch", %{
+      socket: socket,
+      match: match,
+      mate: mate,
+      me: me
+    } do
+      ref =
+        push(socket, "report", %{
+          "user_id" => mate.id,
+          "reason" => "he don't believe in jesus"
+        })
+
+      assert_reply(ref, :ok, _reply)
+
+      # mate gets unmatch message
+      assert_push("unmatched", push)
+      assert push == %{"match_id" => match.id}
+
+      assert %Accounts.UserReport{} =
+               report = Repo.get_by(Accounts.UserReport, from_user_id: me.id, on_user_id: mate.id)
+
+      assert report.reason == "he don't believe in jesus"
+    end
+  end
+
+  defp joined(%{socket: socket, me: me}) do
+    assert {:ok, _reply, socket} =
+             subscribe_and_join(socket, "feed:" <> me.id, %{"mode" => "live"})
+
+    {:ok, socket: socket}
+  end
+
+  defp joined_mate(%{mate: mate}) do
+    socket = connected_socket(mate)
+    {:ok, _reply, socket} = join(socket, "feed:" <> mate.id, %{"mode" => "live"})
+    {:ok, mate_socket: socket}
+  end
+
+  defp session_expiration_date() do
+    {_start_date, end_date} = Feeds.live_mode_start_and_end_dates()
+    end_date
+  end
+end

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -103,6 +103,7 @@ defmodule TWeb.FeedChannelTest do
       assert {:ok, reply, _socket} = join(socket, "feed:" <> me.id)
 
       assert reply == %{
+               "mode" => "normal",
                "likes" => [
                  %{
                    "profile" => %{
@@ -181,6 +182,7 @@ defmodule TWeb.FeedChannelTest do
       assert {:ok, reply, _socket} = join(socket, "feed:" <> me.id)
 
       assert reply == %{
+               "mode" => "normal",
                "missed_calls" => [
                  %{
                    # TODO call without ended_at should be joined from ios?
@@ -213,6 +215,7 @@ defmodule TWeb.FeedChannelTest do
                join(socket, "feed:" <> me.id, %{"missed_calls_cursor" => call_id2})
 
       assert reply == %{
+               "mode" => "normal",
                "missed_calls" => [
                  %{
                    "call" => %{

--- a/test/t_web/channels/user_socket_test.exs
+++ b/test/t_web/channels/user_socket_test.exs
@@ -42,12 +42,12 @@ defmodule TWeb.UserSocketTest do
         |> Accounts.generate_user_session_token("mobile")
         |> Accounts.UserToken.encoded_token()
 
-      assert {:ok, _socket} = connect(UserSocket, %{"token" => token, "version" => "4.6.0"}, %{})
+      assert {:ok, _socket} = connect(UserSocket, %{"token" => token, "version" => "4.7.0"}, %{})
 
       %Accounts.UserToken{version: version} =
         Accounts.UserToken |> where(user_id: ^user.id) |> Repo.one()
 
-      assert version == "ios/4.6.0"
+      assert version == "ios/4.7.0"
     end
 
     test "without token" do
@@ -77,8 +77,8 @@ defmodule TWeb.UserSocketTest do
       |> Accounts.generate_user_session_token("mobile")
       |> Accounts.UserToken.encoded_token()
 
-    {:ok, socket1} = connect(UserSocket, %{"token" => token1, "version" => "4.6.0"}, %{})
-    {:ok, socket2} = connect(UserSocket, %{"token" => token2, "version" => "4.6.0"}, %{})
+    {:ok, socket1} = connect(UserSocket, %{"token" => token1, "version" => "4.7.0"}, %{})
+    {:ok, socket2} = connect(UserSocket, %{"token" => token2, "version" => "4.7.0"}, %{})
 
     socket_id1 = UserSocket.id(socket1)
     socket_id2 = UserSocket.id(socket2)


### PR DESCRIPTION
closes #433 

TODOs
- [x] check if socket assign (normal -> live mode or vice versa) really works (changes behaviour)
- [x] add second slot (Sa, 8-10p)
- [x] custom date / text of Since Live text
- [x] send activated user, differentiate with matches
- [x] live-invite push text
- [x] force version upgrade
- [x] pushes when match is online
- [x] schedule live_mode_activated and live_mode_ended pushes
- [x] allow call for users with live_session
- [x] clear live_sessions and live_invites after session
- [x] log to bot
- [x] not to duplicate live session activation
- [x] fix "more" arriving when the mode already changed
- [x] do not show / send push for invite from reported
- [x] users to be matched after successful call
- [x] user is on another call error
- [x] add tests
- [x] set intended LIVE slots (incl. pushes)
- [x] maybe add a day push (some time in advance before Since LIVE)