### PR TITLE
Speed up tests, and make sure tests work offline

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,6 +7,7 @@ config :t, T.Media.Client, adapter: T.Media.S3Client
 config :t, T.Bot, adapter: T.Bot.API
 config :t, T.PushNotifications.APNS, adapter: T.PushNotifications.APNS.FinchAdapter
 config :t, T.Twilio, adapter: T.Twilio.HTTP
+config :t, T.Accounts.AppleSignIn, adapter: T.Accounts.AppleSignIn.HTTPAdapter
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -4,5 +4,6 @@ config :t, T.Media.Client, adapter: T.Media.S3Client
 config :t, T.Bot, adapter: T.Bot.API
 config :t, T.PushNotifications.APNS, adapter: T.PushNotifications.APNS.FinchAdapter
 config :t, T.Twilio, adapter: T.Twilio.HTTP
+config :t, T.Accounts.AppleSignIn, adapter: T.Accounts.AppleSignIn.HTTPAdapter
 
 config :t, TWeb.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -290,6 +290,7 @@ if config_env() == :test do
   config :t, T.Feeds.SeenPruner, disabled?: true
   config :t, T.Matches.MatchExpirer, disabled?: true
   config :t, T.PushNotifications.ScheduledPushes, disabled?: true
+  config :t, Finch, disabled?: true
 
   # there is no user with this id, it's been generated just for the tests
   config :t, oldies: ["0000017d-d720-1f6a-06e9-e8bbc6570000"]

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,3 +4,4 @@ config :t, T.Media.Client, adapter: StubMediaClient
 config :t, T.Bot, adapter: StubBot
 config :t, T.PushNotifications.APNS, adapter: MockAPNS
 config :t, T.Twilio, adapter: StubTwilio
+config :t, T.Accounts.AppleSignIn, adapter: StubAppleSignIn

--- a/lib/t/accounts/apple_sign_in/adapter.ex
+++ b/lib/t/accounts/apple_sign_in/adapter.ex
@@ -1,0 +1,4 @@
+defmodule T.Accounts.AppleSignIn.Adapter do
+  @moduledoc false
+  @callback fetch_keys :: [map]
+end

--- a/lib/t/accounts/apple_sign_in/http_adapter.ex
+++ b/lib/t/accounts/apple_sign_in/http_adapter.ex
@@ -1,0 +1,16 @@
+defmodule T.Accounts.AppleSignIn.HTTPAdapter do
+  @moduledoc false
+  @behaviour T.Accounts.AppleSignIn.Adapter
+
+  @apple_keys_url "https://appleid.apple.com/auth/keys"
+
+  # TODO can cache? probably not
+  # TODO add retries then
+  @impl true
+  def fetch_keys do
+    req = Finch.build(:get, @apple_keys_url)
+    {:ok, %Finch.Response{status: 200, body: body}} = Finch.request(req, T.Finch)
+    %{"keys" => keys} = Jason.decode!(body)
+    keys
+  end
+end

--- a/lib/t/application.ex
+++ b/lib/t/application.ex
@@ -13,12 +13,14 @@ defmodule T.Application do
         APNS.Token,
         # T.PromEx,
         # TODO add apple keys endpoint and twilio (possibly aws as well)
-        {Finch,
-         name: T.Finch,
-         pools: %{
-           "https://api.development.push.apple.com" => [protocol: :http2],
-           "https://api.push.apple.com" => [protocol: :http2, count: 1]
-         }},
+        unless_disabled(
+          {Finch,
+           name: T.Finch,
+           pools: %{
+             "https://api.development.push.apple.com" => [protocol: :http2],
+             "https://api.push.apple.com" => [protocol: :http2, count: 1]
+           }}
+        ),
         T.Twilio,
         {Phoenix.PubSub, name: T.PubSub},
         unless_disabled(T.Media.Static),
@@ -100,5 +102,9 @@ defmodule T.Application do
 
   defp unless_disabled(mod) when is_atom(mod) do
     unless disabled?(mod), do: mod
+  end
+
+  defp unless_disabled({mod, _opts} = child) when is_atom(mod) do
+    unless disabled?(mod), do: child
   end
 end

--- a/test/support/stub_apple_sign_in.ex
+++ b/test/support/stub_apple_sign_in.ex
@@ -1,0 +1,36 @@
+defmodule StubAppleSignIn do
+  @behaviour T.Accounts.AppleSignIn.Adapter
+
+  @impl true
+  def fetch_keys do
+    [
+      %{
+        "kty" => "RSA",
+        "kid" => "eXaunmL",
+        "use" => "sig",
+        "alg" => "RS256",
+        "n" =>
+          "4dGQ7bQK8LgILOdLsYzfZjkEAoQeVC_aqyc8GC6RX7dq_KvRAQAWPvkam8VQv4GK5T4ogklEKEvj5ISBamdDNq1n52TpxQwI2EqxSk7I9fKPKhRt4F8-2yETlYvye-2s6NeWJim0KBtOVrk0gWvEDgd6WOqJl_yt5WBISvILNyVg1qAAM8JeX6dRPosahRVDjA52G2X-Tip84wqwyRpUlq2ybzcLh3zyhCitBOebiRWDQfG26EH9lTlJhll-p_Dg8vAXxJLIJ4SNLcqgFeZe4OfHLgdzMvxXZJnPp_VgmkcpUdRotazKZumj6dBPcXI_XID4Z4Z3OM1KrZPJNdUhxw",
+        "e" => "AQAB"
+      },
+      %{
+        "kty" => "RSA",
+        "kid" => "86D88Kf",
+        "use" => "sig",
+        "alg" => "RS256",
+        "n" =>
+          "iGaLqP6y-SJCCBq5Hv6pGDbG_SQ11MNjH7rWHcCFYz4hGwHC4lcSurTlV8u3avoVNM8jXevG1Iu1SY11qInqUvjJur--hghr1b56OPJu6H1iKulSxGjEIyDP6c5BdE1uwprYyr4IO9th8fOwCPygjLFrh44XEGbDIFeImwvBAGOhmMB2AD1n1KviyNsH0bEB7phQtiLk-ILjv1bORSRl8AK677-1T8isGfHKXGZ_ZGtStDe7Lu0Ihp8zoUt59kx2o9uWpROkzF56ypresiIl4WprClRCjz8x6cPZXU2qNWhu71TQvUFwvIvbkE1oYaJMb0jcOTmBRZA2QuYw-zHLwQ",
+        "e" => "AQAB"
+      },
+      %{
+        "kty" => "RSA",
+        "kid" => "YuyXoY",
+        "use" => "sig",
+        "alg" => "RS256",
+        "n" =>
+          "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+        "e" => "AQAB"
+      }
+    ]
+  end
+end

--- a/test/t/accounts/accounts_test.exs
+++ b/test/t/accounts/accounts_test.exs
@@ -65,16 +65,18 @@ defmodule T.AccountsTest do
 
   describe "update_last_active/1" do
     test "it works" do
+      now = ~U[2021-12-29 09:10:47.196283Z]
+
       {:ok, %{profile: %Profile{user_id: user_id, last_active: last_active}}} =
-        Accounts.register_user_with_apple_id(%{"apple_id" => apple_id()})
+        Accounts.register_user_with_apple_id(%{"apple_id" => apple_id()}, now)
 
-      assert last_active
+      assert last_active == ~U[2021-12-29 09:10:47Z]
 
-      # TODO
-      :timer.sleep(1000)
+      later = DateTime.add(now, _5_minutes = 300)
+      assert {1, nil} == Accounts.update_last_active(user_id, later)
 
-      assert {1, nil} == Accounts.update_last_active(user_id)
-      refute last_active == Accounts.get_profile!(user_id).last_active
+      %Profile{last_active: last_active} = Accounts.get_profile!(user_id)
+      assert last_active == ~U[2021-12-29 09:15:47Z]
     end
   end
 


### PR DESCRIPTION
I ran `mix test --slowest 5` and noticed that these tests slowest either waited for network (apple sign in keys http request) or just waited (`:timer.sleep` in `update_last_active` test).

I replaced HTTP requests with a stub which returns current apple sign in keys, and used dependency injection for time in the  `update_last_active`.

I also disabled `Finch` in tests to reduce noise from its errors when it can't connect to apple servers when I'm offline.