### PR TITLE
make T.Feeds.NewbiesLiveTest async: false ...

### DIFF
--- a/test/t/feeds/newbies_live_test.exs
+++ b/test/t/feeds/newbies_live_test.exs
@@ -1,5 +1,5 @@
 defmodule T.Feeds.NewbiesLiveTest do
-  use T.DataCase, async: true
+  use T.DataCase
   use Oban.Testing, repo: Repo
   alias T.Feeds
 


### PR DESCRIPTION
… to not interfere with feed channel live tests

fixes `mix test --seed 320414`:

```elixir
  1) test more with active users more than count (TWeb.FeedChanneLiveTest)
     test/t_web/channels/feed_channel_live_test.exs:151
     ** (EXIT from #PID<0.983.0>) an exception was raised:
         ** (MatchError) no match of right hand side value: %{current_user: %T.Accounts.User{__meta__: #Ecto.Schema.Metadata<:loaded, "users">, apple_id: "000701.2ae7cc736a07c2f010c4fdc94d65b3a4.1630", blocked_at: nil, email: nil, id: "0000017e-0b10-a68b-06e9-e8bbc6570000", inserted_at: ~N[2021-12-30 11:19:07], onboarded_at: ~U[2021-12-30 11:19:08Z], onboarded_with_story_at: ~U[2021-12-30 11:19:08Z], profile: #Ecto.Association.NotLoaded<association :profile is not loaded>, settings: #Ecto.Association.NotLoaded<association :settings is not loaded>, updated_at: ~N[2021-12-30 11:19:07]}, feed_filter: %T.Feeds.FeedFilter{distance: nil, genders: ["F", "M", "N"], max_age: nil, min_age: nil}, gender: "M", mode: "normal", screen_width: 1000, token: "KzGqnlyT6OfpEJ7kMtHOD1a0mzCjdjwhGroDVK1L9OI"}
             (t 0.1.6) lib/t_web/channels/feed_channel.ex:160: TWeb.FeedChannel.handle_in/3
             (phoenix 1.6.5) lib/phoenix/channel/server.ex:315: Phoenix.Channel.Server.handle_info/2
             (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
             (stdlib 3.17) gen_server.erl:771: :gen_server.handle_msg/6
             (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```