### PR TITLE
add accepted at to timeslots

### DIFF
--- a/lib/t/matches.ex
+++ b/lib/t/matches.ex
@@ -710,6 +710,7 @@ defmodule T.Matches do
     )
 
     {:ok, slot, 0} = DateTime.from_iso8601(slot)
+    accepted_at = DateTime.truncate(reference, :second)
 
     {picker_name, _number_of_matches1} = user_info(picker)
     {mate_name, _umber_of_matches2} = user_info(mate)
@@ -733,7 +734,7 @@ defmodule T.Matches do
       |> where(picker_id: ^picker)
       |> where([t], ^slot in t.slots)
       |> select([t], t)
-      |> Repo.update_all(set: [selected_slot: slot])
+      |> Repo.update_all(set: [selected_slot: slot, accepted_at: accepted_at])
 
     broadcast_for_user(mate, {__MODULE__, [:timeslot, :accepted], timeslot})
 

--- a/lib/t/matches/timeslot.ex
+++ b/lib/t/matches/timeslot.ex
@@ -11,6 +11,7 @@ defmodule T.Matches.Timeslot do
 
     field :slots, {:array, :utc_datetime}
     field :selected_slot, :utc_datetime
+    field :accepted_at, :utc_datetime
 
     timestamps(updated_at: false)
   end

--- a/lib/t_web/views/match_view.ex
+++ b/lib/t_web/views/match_view.ex
@@ -22,13 +22,17 @@ defmodule TWeb.MatchView do
     match
   end
 
-  defp render_timeslot(%Timeslot{selected_slot: selected_slot})
-       when not is_nil(selected_slot) do
-    %{"selected_slot" => selected_slot}
+  defp render_timeslot(%Timeslot{
+         selected_slot: nil,
+         accepted_at: nil,
+         picker_id: picker,
+         slots: slots
+       }) do
+    %{"slots" => slots, "picker" => picker}
   end
 
-  defp render_timeslot(%Timeslot{picker_id: picker, slots: slots}) do
-    %{"slots" => slots, "picker" => picker}
+  defp render_timeslot(%Timeslot{selected_slot: selected_slot, accepted_at: accepted_at}) do
+    %{"selected_slot" => selected_slot, "accepted_at" => accepted_at}
   end
 
   defp render_contact(%MatchContact{

--- a/priv/repo/migrations/20220111113337_add_timeslots_accepted_at.exs
+++ b/priv/repo/migrations/20220111113337_add_timeslots_accepted_at.exs
@@ -1,0 +1,18 @@
+defmodule T.Repo.Migrations.AddTimeslotsAcceptedAt do
+  use Ecto.Migration
+  import Ecto.Query
+  alias T.Repo
+
+  def change do
+    alter table(:match_timeslot) do
+      add :accepted_at, :utc_datetime
+    end
+
+    flush()
+
+    "match_timeslot"
+    |> where([t], not is_nil(t.selected_slot))
+    |> update([t], set: [accepted_at: t.inserted_at])
+    |> Repo.update_all([])
+  end
+end

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -33,26 +33,20 @@ defmodule TWeb.FeedChannelTest do
         insert(:match, user_id_1: me.id, user_id_2: p3.id, inserted_at: ~N[2021-09-30 12:16:07])
       ]
 
-      # if it's 14:47 right now ...
-      %DateTime{hour: next_hour} = dt = DateTime.utc_now() |> DateTime.add(_seconds = 3600)
-      date = DateTime.to_date(dt)
+      now = ~U[2021-09-30 14:47:00.123456Z]
 
-      # ... then the slots are
       slots = [
-        # 15:15
-        DateTime.new!(date, Time.new!(next_hour, 15, 0)),
-        # 15:30
-        s2 = DateTime.new!(date, Time.new!(next_hour, 30, 0)),
-        # 15:45
-        DateTime.new!(date, Time.new!(next_hour, 45, 0))
+        ~U[2021-09-30 15:15:00Z],
+        s2 = ~U[2021-09-30 15:30:00Z],
+        ~U[2021-09-30 15:45:00Z]
       ]
 
       raw_slots = Enum.map(slots, &DateTime.to_iso8601/1)
 
-      Matches.save_slots_offer_for_match(p2.id, m2.id, raw_slots)
+      Matches.save_slots_offer_for_match(p2.id, m2.id, raw_slots, now)
 
-      Matches.save_slots_offer_for_match(me.id, m3.id, raw_slots)
-      Matches.accept_slot_for_match(p3.id, m3.id, DateTime.to_iso8601(s2))
+      Matches.save_slots_offer_for_match(me.id, m3.id, raw_slots, now)
+      Matches.accept_slot_for_match(p3.id, m3.id, DateTime.to_iso8601(s2), now)
 
       # add contact to m1
 
@@ -76,7 +70,7 @@ defmodule TWeb.FeedChannelTest do
                %{
                  "id" => m3.id,
                  "profile" => %{name: "mate-3", story: [], user_id: p3.id, gender: "M"},
-                 "timeslot" => %{"selected_slot" => s2},
+                 "timeslot" => %{"selected_slot" => s2, "accepted_at" => ~U[2021-09-30 14:47:00Z]},
                  "audio_only" => false,
                  "expiration_date" => ~U[2021-10-07 12:16:07Z]
                },


### PR DESCRIPTION
Since the only place where `updated_at` could be used is `accept_slot`, I named it `accepted_at`.

The interactions can then be sorted like:

```elixir
interactions
|> Enum.sort_by(fn
    %Timeslot{inserted_at: inserted_at, accepted_at: accepted_at} -> accepted_at || inserted_at
    # other interactions
  end,
  {DateTime, :desc}
)
```