### PR TITLE
disable arm64 builds in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   docker:
-    name: docker buildx amd64/arm64
+    name: docker build amd64
     runs-on: ubuntu-latest
 
     permissions:
@@ -21,8 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # platforms: linux/amd64,linux/arm64
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
It's just way too slow and the cache is invalidated too often, so it falls back to almost full rebuild which takes in qemu ~20 minutes. I'll try some [workarounds](https://github.com/ruslandoga/elixir-github-actions-arm64/commit/1d7309d60fd6c37ee9f6c8898f628fa62397c8fe) over the next few weeks but right now it's not worth having arm64 images given that cost.