### PR TITLE
disable Since LIVE

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -27,8 +27,11 @@ config :sentry,
 config :t, T.PromEx, disabled: config_env() != :prod
 
 newbies_live_enabled? = !!System.get_env("ENABLE_NEWBIE_LIVE")
+since_live_enabled? = !!System.get_env("ENABLE_SINCE_LIVE")
 
-config :t, newbies_live_enabled?: newbies_live_enabled?
+config :t,
+  newbies_live_enabled?: newbies_live_enabled?,
+  since_live_enabled?: since_live_enabled?
 
 crontab =
   case config_env() do
@@ -37,7 +40,9 @@ crontab =
         if newbies_live_enabled? do
           T.Feeds.newbies_crontab()
         end,
-        T.Feeds.live_crontab()
+        if since_live_enabled? do
+          T.Feeds.live_crontab()
+        end
       ]
       |> Enum.reject(&is_nil/1)
       |> List.flatten()
@@ -235,6 +240,9 @@ end
 
 if config_env() == :test do
   config :t, current_admin_id: "36a0a181-db31-400a-8397-db7f560c152e"
+
+  # to keep tests working
+  config :t, since_live_enabled?: true
 
   # Configure your database
   #

--- a/lib/t/feeds.ex
+++ b/lib/t/feeds.ex
@@ -60,10 +60,9 @@ defmodule T.Feeds do
       {_mon = 1, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
       {_tue = 2, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
       {_wed = 3, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
-      # {_thu = 4, :real, [_start = ~T[19:00:00], _end = ~T[21:00:00]]},
-      {_thu = 4, :newbie, [_start = ~T[19:00:00], _end = ~T[21:00:00]]},
+      {_thu = 4, :real, [_start = ~T[19:00:00], _end = ~T[21:00:00]]},
       {_fri = 5, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
-      {_sat = 6, :real, [_start = ~T[20:00:00], _end = ~T[22:00:00]]},
+      {_sat = 6, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
       {_sun = 7, :newbie, [newbies_live_start_at(), newbies_live_end_at()]}
     ]
   end
@@ -88,10 +87,10 @@ defmodule T.Feeds do
       iex> live_next_real_at(thu_21_00)
       _thu_19_00_as_utc = ~U[2021-12-23 16:00:00Z]
 
-      # if today's event has ended, next event is returned
-      iex> thu_21_00_01 = DateTime.new!(~D[2021-12-23], ~T[21:00:01], "Europe/Moscow")
-      iex> live_next_real_at(thu_21_00_01)
-      _sat_20_00_as_utc = ~U[2021-12-25 17:00:00Z]
+      # # if today's event has ended, next event is returned
+      # iex> thu_21_00_01 = DateTime.new!(~D[2021-12-23], ~T[21:00:01], "Europe/Moscow")
+      # iex> live_next_real_at(thu_21_00_01)
+      # _sat_20_00_as_utc = ~U[2021-12-25 17:00:00Z]
 
       # schedule wraps over to the next week
       iex> sun_12_00 = DateTime.new!(~D[2021-12-26], ~T[12:00:00], "Europe/Moscow")
@@ -183,14 +182,14 @@ defmodule T.Feeds do
       iex> live_today(_now = thu_12_00)
       {:real, [~U[2021-12-23 16:00:00Z], ~U[2021-12-23 18:00:00Z]]}
 
-      iex> sat_12_00 = DateTime.new!(~D[2021-12-25], ~T[12:00:00], "Europe/Moscow")
-      iex> live_today(_now = sat_12_00)
-      {:real, [~U[2021-12-25 17:00:00Z], ~U[2021-12-25 19:00:00Z]]}
+      # iex> sat_12_00 = DateTime.new!(~D[2021-12-25], ~T[12:00:00], "Europe/Moscow")
+      # iex> live_today(_now = sat_12_00)
+      # {:real, [~U[2021-12-25 17:00:00Z], ~U[2021-12-25 19:00:00Z]]}
 
-      # note that past events for today might be returned
-      iex> sat_23_00 = DateTime.new!(~D[2021-12-25], ~T[23:00:00], "Europe/Moscow")
-      iex> live_today(_now = sat_23_00)
-      {:real, [~U[2021-12-25 17:00:00Z], ~U[2021-12-25 19:00:00Z]]}
+      # # note that past events for today might be returned
+      # iex> sat_23_00 = DateTime.new!(~D[2021-12-25], ~T[23:00:00], "Europe/Moscow")
+      # iex> live_today(_now = sat_23_00)
+      # {:real, [~U[2021-12-25 17:00:00Z], ~U[2021-12-25 19:00:00Z]]}
 
   """
   @spec live_today(DateTime.t() | Date.t()) :: {:real | :newbie, [DateTime.t()]}
@@ -221,18 +220,18 @@ defmodule T.Feeds do
   @doc """
   Generates "Since Live" `:crontab` for Oban's `Oban.Plugins.Cron`:
 
-      iex> live_crontab()
-      [
-        # https://crontab.guru/#0_13_*_*_4
-        {"00 13 * * 4", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_today", "time" => "19:00"}},
-        {"45 18 * * 4", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_soon"}},
-        {"00 19 * * 4", T.Feeds.Live.StartJob},
-        {"00 21 * * 4", T.Feeds.Live.EndJob},
-        {"00 14 * * 6", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_today", "time" => "20:00"}},
-        {"45 19 * * 6", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_soon"}},
-        {"00 20 * * 6", T.Feeds.Live.StartJob},
-        {"00 22 * * 6", T.Feeds.Live.EndJob}
-      ]
+      # iex> live_crontab()
+      # [
+      #   # https://crontab.guru/#0_13_*_*_4
+      #   {"00 13 * * 4", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_today", "time" => "19:00"}},
+      #   {"45 18 * * 4", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_soon"}},
+      #   {"00 19 * * 4", T.Feeds.Live.StartJob},
+      #   {"00 21 * * 4", T.Feeds.Live.EndJob},
+      #   {"00 14 * * 6", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_today", "time" => "20:00"}},
+      #   {"45 19 * * 6", T.PushNotifications.DispatchJob, args: %{"type" => "live_mode_soon"}},
+      #   {"00 20 * * 6", T.Feeds.Live.StartJob},
+      #   {"00 22 * * 6", T.Feeds.Live.EndJob}
+      # ]
 
   """
   def live_crontab do
@@ -894,14 +893,14 @@ defmodule T.Feeds do
   @doc """
   Generates "Since Live for newbies" `:crontab` for Oban's `Oban.Plugins.Cron`:
 
-      iex> newbies_crontab()
-      [
-        # https://crontab.guru/#0_13_*_*_1,2,3,5,0
-        {"00 13 * * 1,2,3,5,0", T.PushNotifications.DispatchJob, args: %{"type" => "newbie_live_mode_today", "time" => "19:00"}},
-        {"45 18 * * 1,2,3,5,0", T.PushNotifications.DispatchJob, args: %{"type" => "newbie_live_mode_soon"}},
-        {"00 19 * * 1,2,3,5,0", T.Feeds.NewbiesLive.StartJob},
-        {"00 20 * * 1,2,3,5,0", T.Feeds.NewbiesLive.EndJob}
-      ]
+      # iex> newbies_crontab()
+      # [
+      #   # https://crontab.guru/#0_13_*_*_1,2,3,5,0
+      #   {"00 13 * * 1,2,3,5,0", T.PushNotifications.DispatchJob, args: %{"type" => "newbie_live_mode_today", "time" => "19:00"}},
+      #   {"45 18 * * 1,2,3,5,0", T.PushNotifications.DispatchJob, args: %{"type" => "newbie_live_mode_soon"}},
+      #   {"00 19 * * 1,2,3,5,0", T.Feeds.NewbiesLive.StartJob},
+      #   {"00 20 * * 1,2,3,5,0", T.Feeds.NewbiesLive.EndJob}
+      # ]
 
   """
   def newbies_crontab do

--- a/lib/t/feeds.ex
+++ b/lib/t/feeds.ex
@@ -60,7 +60,8 @@ defmodule T.Feeds do
       {_mon = 1, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
       {_tue = 2, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
       {_wed = 3, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
-      {_thu = 4, :real, [_start = ~T[19:00:00], _end = ~T[21:00:00]]},
+      # {_thu = 4, :real, [_start = ~T[19:00:00], _end = ~T[21:00:00]]},
+      {_thu = 4, :newbie, [_start = ~T[19:00:00], _end = ~T[21:00:00]]},
       {_fri = 5, :newbie, [newbies_live_start_at(), newbies_live_end_at()]},
       {_sat = 6, :real, [_start = ~T[20:00:00], _end = ~T[22:00:00]]},
       {_sun = 7, :newbie, [newbies_live_start_at(), newbies_live_end_at()]}

--- a/lib/t_web/channels/feed_channel.ex
+++ b/lib/t_web/channels/feed_channel.ex
@@ -17,16 +17,21 @@ defmodule TWeb.FeedChannel do
       :ok = Feeds.subscribe_for_user(user_id)
       :ok = Feeds.subscribe_for_mode_change()
 
-      newbies_live_enabled? = Application.get_env(:t, :newbies_live_enabled?)
+      newbies_live_enabled? = Feeds.live_newbies_enabled?()
+      live_enabled? = Feeds.live_enabled?()
+      utc_now = utc_now(socket)
 
       cond do
         params["mode"] == "normal" ->
           join_normal_mode(user_id, screen_width, params, socket)
 
-        params["mode"] == "live" ->
+        live_enabled? and params["mode"] == "live" ->
           join_live_mode(user_id, screen_width, socket)
 
-        Feeds.live_now?(user_id, utc_now(socket), newbies_live_enabled?) ->
+        live_enabled? and Feeds.live_now?(utc_now) ->
+          join_live_mode(user_id, screen_width, socket)
+
+        newbies_live_enabled? and Feeds.newbies_live_now?(user_id, utc_now) ->
           join_live_mode(user_id, screen_width, socket)
 
         true ->

--- a/test/t/feeds/feeds_live_test.exs
+++ b/test/t/feeds/feeds_live_test.exs
@@ -9,40 +9,35 @@ defmodule T.FeedsLiveTest do
   import Mox
   setup :verify_on_exit!
 
-  describe "live_now?/1,2" do
-    setup do
-      {:ok, user_id: Ecto.UUID.generate()}
+  describe "live_now?/1" do
+    test "Thursday" do
+      refute Feeds.live_now?(msk(~D[2021-12-09], ~T[18:59:59]))
+
+      assert Feeds.live_now?(msk(~D[2021-12-09], ~T[19:00:00]))
+      assert Feeds.live_now?(msk(~D[2021-12-09], ~T[19:00:01]))
+      assert Feeds.live_now?(msk(~D[2021-12-09], ~T[20:59:59]))
+      assert Feeds.live_now?(msk(~D[2021-12-09], ~T[21:00:00]))
+
+      refute Feeds.live_now?(msk(~D[2021-12-09], ~T[21:00:01]))
     end
 
-    test "Thursday", %{user_id: user_id} do
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-09], ~T[18:59:59]))
+    test "Saturday" do
+      refute Feeds.live_now?(msk(~D[2021-12-11], ~T[19:59:59]))
 
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-09], ~T[19:00:00]))
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-09], ~T[19:00:01]))
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-09], ~T[20:59:59]))
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-09], ~T[21:00:00]))
+      assert Feeds.live_now?(msk(~D[2021-12-11], ~T[20:00:00]))
+      assert Feeds.live_now?(msk(~D[2021-12-11], ~T[20:00:01]))
+      assert Feeds.live_now?(msk(~D[2021-12-11], ~T[21:59:59]))
+      assert Feeds.live_now?(msk(~D[2021-12-11], ~T[22:00:00]))
 
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-09], ~T[21:00:01]))
+      refute Feeds.live_now?(msk(~D[2021-12-11], ~T[22:00:01]))
     end
 
-    @tag skip: true
-    test "Saturday", %{user_id: user_id} do
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-11], ~T[19:59:59]))
-
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-11], ~T[20:00:00]))
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-11], ~T[20:00:01]))
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-11], ~T[21:59:59]))
-      assert Feeds.live_now?(user_id, msk(~D[2021-12-11], ~T[22:00:00]))
-
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-11], ~T[22:00:01]))
-    end
-
-    test "Monday", %{user_id: user_id} do
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-06], ~T[18:00:00]))
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-06], ~T[19:00:00]))
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-06], ~T[20:00:00]))
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-06], ~T[21:00:00]))
-      refute Feeds.live_now?(user_id, msk(~D[2021-12-06], ~T[22:00:00]))
+    test "Monday" do
+      refute Feeds.live_now?(msk(~D[2021-12-06], ~T[18:00:00]))
+      refute Feeds.live_now?(msk(~D[2021-12-06], ~T[19:00:00]))
+      refute Feeds.live_now?(msk(~D[2021-12-06], ~T[20:00:00]))
+      refute Feeds.live_now?(msk(~D[2021-12-06], ~T[21:00:00]))
+      refute Feeds.live_now?(msk(~D[2021-12-06], ~T[22:00:00]))
     end
   end
 

--- a/test/t/feeds/feeds_live_test.exs
+++ b/test/t/feeds/feeds_live_test.exs
@@ -25,6 +25,7 @@ defmodule T.FeedsLiveTest do
       refute Feeds.live_now?(user_id, msk(~D[2021-12-09], ~T[21:00:01]))
     end
 
+    @tag skip: true
     test "Saturday", %{user_id: user_id} do
       refute Feeds.live_now?(user_id, msk(~D[2021-12-11], ~T[19:59:59]))
 

--- a/test/t/feeds/newbies_live_test.exs
+++ b/test/t/feeds/newbies_live_test.exs
@@ -72,13 +72,13 @@ defmodule T.Feeds.NewbiesLiveTest do
     end
   end
 
-  describe "live_now?/1,2" do
+  describe "newbies_live_now?/1,2" do
     test "returns false when no ongoing event and user is participant" do
       oldie = List.first(@oldies)
       %{id: newbie} = newbie_user(onboarded_at: msk(~D[2021-12-19], ~T[09:47:57]))
 
       for time <- [~T[18:59:59], ~T[20:00:01]], user <- [oldie, newbie] do
-        refute Feeds.live_now?(user, msk(~D[2021-12-19], time), _newbies_live_enabled? = true)
+        refute Feeds.newbies_live_now?(user, msk(~D[2021-12-19], time))
       end
     end
 
@@ -90,7 +90,7 @@ defmodule T.Feeds.NewbiesLiveTest do
       times = [~T[19:00:00], ~T[19:00:01], ~T[19:59:59], ~T[20:00:00]]
 
       for time <- times, user <- users do
-        assert Feeds.live_now?(user, msk(~D[2021-12-19], time), _newbies_live_enabled? = true)
+        assert Feeds.newbies_live_now?(user, msk(~D[2021-12-19], time))
       end
     end
 
@@ -99,7 +99,7 @@ defmodule T.Feeds.NewbiesLiveTest do
       times = [~T[18:59:59], ~T[19:00:00], ~T[19:59:59], ~T[20:00:00], ~T[20:00:01]]
 
       for time <- times do
-        refute Feeds.live_now?(old, msk(~D[2021-12-19], time), _newbies_live_enabled? = true)
+        refute Feeds.newbies_live_now?(old, msk(~D[2021-12-19], time))
       end
     end
   end

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -901,7 +901,7 @@ defmodule TWeb.FeedChannelTest do
       ref = push(socket, "call", %{"user_id" => mate.id})
       assert_reply(ref, :error, reply)
 
-      if Feeds.live_now?(mate.id) do
+      if Feeds.live_now?() do
         assert reply == %{"reason" => "no pushkit devices available"}
       else
         assert reply == %{"reason" => "call not allowed"}


### PR DESCRIPTION
@ruslandoga I will deploy this so that:
a) users won't receive "there is Since LIVE today" push notification @ 1pm MSC
b) there won't be Since LIVE tomorrow (as potentially the new version will be out by then; and new version doesn't support Since LIVE)

~~but obviously we need to do this in a proper way, probably with is_live_enabled variable in .envrc file
could you please do it?~~

related #545 