### PR TITLE
add distance to likes and unseen matches

### DIFF
--- a/dev/dev.ex
+++ b/dev/dev.ex
@@ -47,5 +47,3 @@ defmodule Dev do
     end
   end
 end
-
-# force github actions eh

--- a/dev/dev.ex
+++ b/dev/dev.ex
@@ -47,3 +47,5 @@ defmodule Dev do
     end
   end
 end
+
+# force github actions eh

--- a/lib/t/feeds.ex
+++ b/lib/t/feeds.ex
@@ -272,8 +272,10 @@ defmodule T.Feeds do
   ### Likes
 
   # TODO accept cursor
-  @spec list_received_likes(Ecto.UUID.t()) :: [%{profile: %FeedProfile{}, seen: boolean()}]
-  def list_received_likes(user_id) do
+  @spec list_received_likes(Ecto.UUID.t(), Geo.Point.t()) :: [
+          %{profile: %FeedProfile{}, seen: boolean()}
+        ]
+  def list_received_likes(user_id, location) do
     profiles_q = not_reported_profiles_q(user_id)
 
     Like
@@ -283,7 +285,10 @@ defmodule T.Feeds do
     |> not_match2_profiles_q(user_id)
     |> order_by(desc: :inserted_at)
     |> join(:inner, [l], p in subquery(profiles_q), on: p.user_id == l.by_user_id)
-    |> select([l, p], %{profile: p, seen: l.seen})
+    |> select([l, p], %{
+      profile: %{p | distance: distance_km(^location, p.location)},
+      seen: l.seen
+    })
     |> Repo.all()
   end
 

--- a/lib/t/feeds.ex
+++ b/lib/t/feeds.ex
@@ -192,10 +192,11 @@ defmodule T.Feeds do
     %FeedFilter{genders: genders, min_age: min_age, max_age: max_age, distance: distance}
   end
 
-  @spec get_mate_feed_profile(Ecto.UUID.t()) :: %FeedProfile{} | nil
-  def get_mate_feed_profile(user_id) do
+  @spec get_mate_feed_profile(Ecto.UUID.t(), Geo.Point.t()) :: %FeedProfile{} | nil
+  def get_mate_feed_profile(user_id, location) do
     not_hidden_profiles_q()
     |> where(user_id: ^user_id)
+    |> select([p], %{p | distance: distance_km(^location, p.location)})
     |> Repo.one()
   end
 

--- a/lib/t/matches.ex
+++ b/lib/t/matches.ex
@@ -52,14 +52,12 @@ defmodule T.Matches do
     end
   end
 
-  defp default_location, do: %Geo.Point{coordinates: {0, 0}, srid: 4326}
-
   # - Likes
   @spec like_user(Ecto.UUID.t(), Ecto.UUID.t(), Geo.Point.t()) ::
           {:ok, %{match: %Match{} | nil, mutual: %FeedProfile{} | nil}}
           | {:error, atom, term, map}
 
-  def like_user(by_user_id, user_id, location \\ default_location()) do
+  def like_user(by_user_id, user_id, location) do
     primary_rpc(__MODULE__, :local_like_user, [by_user_id, user_id, location])
   end
 
@@ -247,7 +245,7 @@ defmodule T.Matches do
   # - Matches
 
   @spec list_matches(uuid, Geo.Point.t()) :: [%Match{}]
-  def list_matches(user_id, location \\ default_location()) do
+  def list_matches(user_id, location) do
     matches_with_undying_events_q()
     |> where([match: m], m.user_id_1 == ^user_id or m.user_id_2 == ^user_id)
     |> order_by(desc: :inserted_at)

--- a/lib/t_web/channels/feed_channel.ex
+++ b/lib/t_web/channels/feed_channel.ex
@@ -439,8 +439,12 @@ defmodule TWeb.FeedChannel do
   end
 
   @compile inline: [render_match: 1]
-  defp render_match(assigns) do
+  defp render_match(%{seen: true} = assigns) do
     render(MatchView, "match.json", assigns)
+  end
+
+  defp render_match(assigns) do
+    render(MatchView, "match_with_distance.json", assigns)
   end
 
   defp render_news(news, version, screen_width) do

--- a/lib/t_web/channels/feed_channel.ex
+++ b/lib/t_web/channels/feed_channel.ex
@@ -32,7 +32,7 @@ defmodule TWeb.FeedChannel do
 
     likes =
       user_id
-      |> Feeds.list_received_likes()
+      |> Feeds.list_received_likes(location)
       |> render_likes(version, screen_width)
 
     matches =

--- a/lib/t_web/channels/feed_channel.ex
+++ b/lib/t_web/channels/feed_channel.ex
@@ -37,7 +37,7 @@ defmodule TWeb.FeedChannel do
 
     matches =
       user_id
-      |> Matches.list_matches()
+      |> Matches.list_matches(location)
       |> render_matches(version, screen_width)
 
     news =

--- a/lib/t_web/channels/feed_channel.ex
+++ b/lib/t_web/channels/feed_channel.ex
@@ -337,10 +337,10 @@ defmodule TWeb.FeedChannel do
 
   @impl true
   def handle_info({Matches, :liked, like}, socket) do
-    %{screen_width: screen_width, version: version} = socket.assigns
+    %{screen_width: screen_width, version: version, location: location} = socket.assigns
     %{by_user_id: by_user_id} = like
 
-    if profile = Feeds.get_mate_feed_profile(by_user_id) do
+    if profile = Feeds.get_mate_feed_profile(by_user_id, location) do
       rendered = render_feed_item(profile, version, screen_width)
       push(socket, "invite", rendered)
     end
@@ -349,7 +349,7 @@ defmodule TWeb.FeedChannel do
   end
 
   def handle_info({Matches, :matched, match}, socket) do
-    %{screen_width: screen_width, version: version} = socket.assigns
+    %{screen_width: screen_width, version: version, location: location} = socket.assigns
 
     %{
       id: match_id,
@@ -358,7 +358,7 @@ defmodule TWeb.FeedChannel do
       mate: mate_id
     } = match
 
-    if profile = Feeds.get_mate_feed_profile(mate_id) do
+    if profile = Feeds.get_mate_feed_profile(mate_id, location) do
       push(socket, "matched", %{
         "match" =>
           render_match(%{

--- a/lib/t_web/channels/feed_channel.ex
+++ b/lib/t_web/channels/feed_channel.ex
@@ -170,12 +170,17 @@ defmodule TWeb.FeedChannel do
   end
 
   def handle_in("like", %{"user_id" => liked}, socket) do
-    %{current_user: %{id: liker}, screen_width: screen_width, version: version} = socket.assigns
+    %{
+      current_user: %{id: liker},
+      screen_width: screen_width,
+      version: version,
+      location: location
+    } = socket.assigns
 
     Events.save_like(liker, liked)
 
     reply =
-      case Matches.like_user(liker, liked) do
+      case Matches.like_user(liker, liked, location) do
         {:ok, %{match: _no_match = nil}} ->
           :ok
 

--- a/lib/t_web/views/feed_view.ex
+++ b/lib/t_web/views/feed_view.ex
@@ -30,6 +30,20 @@ defmodule TWeb.FeedView do
     )
   end
 
+  def render("feed_profile_with_distance.json", %{
+        profile: profile,
+        version: version,
+        screen_width: screen_width
+      }) do
+    render_profile(
+      profile,
+      [:user_id, :name, :gender, :story, :distance],
+      version,
+      screen_width,
+      _env = :match
+    )
+  end
+
   defp render_profile(%FeedProfile{} = profile, fields, version, screen_width, env) do
     profile
     |> Map.take(fields)

--- a/lib/t_web/views/match_view.ex
+++ b/lib/t_web/views/match_view.ex
@@ -9,6 +9,13 @@ defmodule TWeb.MatchView do
     |> maybe_put("seen", assigns[:seen])
   end
 
+  def render("match_with_distance.json", %{id: id} = assigns) do
+    %{"id" => id, "profile" => render(FeedView, "feed_profile_with_distance.json", assigns)}
+    |> maybe_put("inserted_at", ensure_utc(assigns[:inserted_at]))
+    |> maybe_put("expiration_date", ensure_utc(assigns[:expiration_date]))
+    |> maybe_put("seen", assigns[:seen])
+  end
+
   defp maybe_put(map, _k, nil), do: map
   defp maybe_put(map, _k, false), do: map
   defp maybe_put(map, k, v), do: Map.put(map, k, v)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -98,6 +98,8 @@ defmodule T.Factory do
     [lat: 37.331647, lon: -122.029970]
   end
 
+  def default_location, do: %Geo.Point{coordinates: {0, 0}, srid: 4326}
+
   def onboarding_attrs(opts \\ []) do
     gender = opts[:gender] || "M"
     %{lat: lat, lon: lon} = Map.new(opts[:location] || [lat: 55.755833, lon: 37.617222])

--- a/test/t/accounts/blocking_test.exs
+++ b/test/t/accounts/blocking_test.exs
@@ -25,10 +25,11 @@ defmodule T.Accounts.BlockingTest do
       Matches.subscribe_for_user(reporter.id)
       Matches.subscribe_for_user(reported.id)
 
-      assert {:ok, %{match: nil}} = Matches.like_user(reporter.id, reported.id)
+      assert {:ok, %{match: nil}} =
+               Matches.like_user(reporter.id, reported.id, default_location())
 
       assert {:ok, %{match: %Match{id: match_id, inserted_at: inserted_at}}} =
-               Matches.like_user(reported.id, reporter.id)
+               Matches.like_user(reported.id, reporter.id, default_location())
 
       expiration_date =
         inserted_at
@@ -48,8 +49,8 @@ defmodule T.Accounts.BlockingTest do
       assert :ok == Accounts.report_user(reporter.id, reported.id, "he show dicky")
       assert_receive {Matches, :unmatched, ^match_id}
 
-      assert [] == Matches.list_matches(reported.id)
-      assert [] == Matches.list_matches(reporter.id)
+      assert [] == Matches.list_matches(reported.id, default_location())
+      assert [] == Matches.list_matches(reporter.id, default_location())
     end
 
     test "3 reports block the user", %{reporter: reporter1, reported: reported} do
@@ -84,8 +85,10 @@ defmodule T.Accounts.BlockingTest do
     test "unmatches if there is a match", %{user: user} do
       other = onboarded_user()
 
-      assert {:ok, %{match: nil}} = Matches.like_user(user.id, other.id)
-      assert {:ok, %{match: %Match{id: match_id}}} = Matches.like_user(other.id, user.id)
+      assert {:ok, %{match: nil}} = Matches.like_user(user.id, other.id, default_location())
+
+      assert {:ok, %{match: %Match{id: match_id}}} =
+               Matches.like_user(other.id, user.id, default_location())
 
       Matches.subscribe_for_user(user.id)
       Matches.subscribe_for_user(other.id)
@@ -94,8 +97,8 @@ defmodule T.Accounts.BlockingTest do
 
       assert_receive {Matches, :unmatched, ^match_id}
 
-      assert [] == Matches.list_matches(user.id)
-      assert [] == Matches.list_matches(other.id)
+      assert [] == Matches.list_matches(user.id, default_location())
+      assert [] == Matches.list_matches(other.id, default_location())
     end
 
     test "blocked user is hidden", %{user: user} do

--- a/test/t/accounts/deletion_test.exs
+++ b/test/t/accounts/deletion_test.exs
@@ -31,10 +31,10 @@ defmodule T.Accounts.DeletionTest do
       Matches.subscribe_for_user(user.id)
       Matches.subscribe_for_user(p2.user_id)
 
-      assert {:ok, %{match: nil}} = Matches.like_user(p2.user_id, user.id)
+      assert {:ok, %{match: nil}} = Matches.like_user(p2.user_id, user.id, default_location())
 
       assert {:ok, %{match: %Match{id: match_id, inserted_at: inserted_at}}} =
-               Matches.like_user(user.id, p2.user_id)
+               Matches.like_user(user.id, p2.user_id, default_location())
 
       expiration_date =
         inserted_at
@@ -53,7 +53,7 @@ defmodule T.Accounts.DeletionTest do
 
       assert {:ok, %{delete_user: true, unmatch: [true]}} = Accounts.delete_user(user.id)
       assert_receive {Matches, :unmatched, ^match_id}
-      assert [] == Matches.list_matches(p2.user_id)
+      assert [] == Matches.list_matches(p2.user_id, default_location())
     end
   end
 end

--- a/test/t/matches/contacts_test.exs
+++ b/test/t/matches/contacts_test.exs
@@ -8,8 +8,8 @@ defmodule T.Matches.ContactsTest do
 
     test "saves contact_click events", %{match: match} do
       assert {:ok, _event} = Matches.save_contact_click(match.id)
-      assert [%{expiration_date: nil}] = Matches.list_matches(match.user_id_1)
-      assert [%{expiration_date: nil}] = Matches.list_matches(match.user_id_2)
+      assert [%{expiration_date: nil}] = Matches.list_matches(match.user_id_1, default_location())
+      assert [%{expiration_date: nil}] = Matches.list_matches(match.user_id_2, default_location())
     end
   end
 

--- a/test/t/matches/matches_test.exs
+++ b/test/t/matches/matches_test.exs
@@ -20,7 +20,7 @@ defmodule T.MatchesTest do
         Matches.subscribe_for_user(p2_id)
 
         Ecto.Adapters.SQL.Sandbox.allow(Repo, parent, self())
-        assert {:ok, %{match: nil}} = Matches.like_user(p1_id, p2_id)
+        assert {:ok, %{match: nil}} = Matches.like_user(p1_id, p2_id, default_location())
 
         # TODO why do we get matched message?
         # refute_receive _anything, 1
@@ -31,16 +31,17 @@ defmodule T.MatchesTest do
 
       assert [%Like{by_user_id: ^p1_id, user_id: ^p2_id}] = list_likes_for(p2_id)
 
-      assert {:ok, %{match: %Match{id: match_id}}} = Matches.like_user(p2_id, p1_id)
+      assert {:ok, %{match: %Match{id: match_id}}} =
+               Matches.like_user(p2_id, p1_id, default_location())
 
       # for p1
       assert_receive {Matches, :matched, %{id: ^match_id, mate: ^p2_id}}
 
       assert [%Match{id: ^match_id, profile: %FeedProfile{user_id: ^p2_id}}] =
-               Matches.list_matches(p1_id)
+               Matches.list_matches(p1_id, default_location())
 
       assert [%Match{id: ^match_id, profile: %FeedProfile{user_id: ^p1_id}}] =
-               Matches.list_matches(p2_id)
+               Matches.list_matches(p2_id, default_location())
 
       spawn(fn ->
         Ecto.Adapters.SQL.Sandbox.allow(Repo, parent, self())
@@ -52,8 +53,8 @@ defmodule T.MatchesTest do
       # for p2
       assert_receive {Matches, :unmatched, ^match_id}
 
-      assert [] == Matches.list_matches(p1_id)
-      assert [] == Matches.list_matches(p2_id)
+      assert [] == Matches.list_matches(p1_id, default_location())
+      assert [] == Matches.list_matches(p2_id, default_location())
 
       assert [] == list_likes_for(p1_id)
       assert [] == list_likes_for(p2_id)
@@ -75,7 +76,7 @@ defmodule T.MatchesTest do
       [%{user_id: liked}, %{user_id: liker1}, %{user_id: liker2}, %{user_id: liker3}] =
         insert_list(4, :profile, hidden?: false)
 
-      Matches.like_user(liker1, liked)
+      Matches.like_user(liker1, liked, default_location())
 
       assert FeedProfile
              |> where(user_id: ^liked)
@@ -91,7 +92,7 @@ defmodule T.MatchesTest do
              |> select([p], {p.times_liked, p.like_ratio})
              |> Repo.one!() == {1, 0.5}
 
-      Matches.like_user(liker3, liked)
+      Matches.like_user(liker3, liked, default_location())
 
       assert FeedProfile
              |> where(user_id: ^liked)
@@ -112,7 +113,7 @@ defmodule T.MatchesTest do
       me = onboarded_user()
       liker = onboarded_user()
 
-      {:ok, _} = Matches.like_user(liker.id, me.id)
+      {:ok, _} = Matches.like_user(liker.id, me.id, default_location())
 
       assert %Like{seen: false} =
                Like |> where(by_user_id: ^liker.id) |> where(user_id: ^me.id) |> Repo.one!()
@@ -124,7 +125,7 @@ defmodule T.MatchesTest do
     end
   end
 
-  describe "list_matches/1" do
+  describe "list_matches/2" do
     setup do
       p1 = insert(:profile)
       p2 = insert(:profile)
@@ -136,8 +137,11 @@ defmodule T.MatchesTest do
       %{profiles: [%{user_id: u1_id}, %{user_id: u2_id}], match: %{id: match_id}} = ctx
       insert(:match_event, match_id: match_id, timestamp: DateTime.utc_now(), event: "call_start")
 
-      assert [%Match{id: ^match_id, expiration_date: nil}] = Matches.list_matches(u1_id)
-      assert [%Match{id: ^match_id, expiration_date: nil}] = Matches.list_matches(u2_id)
+      assert [%Match{id: ^match_id, expiration_date: nil}] =
+               Matches.list_matches(u1_id, default_location())
+
+      assert [%Match{id: ^match_id, expiration_date: nil}] =
+               Matches.list_matches(u2_id, default_location())
     end
 
     test "matches with contact offer don't have expiration date", ctx do
@@ -149,8 +153,11 @@ defmodule T.MatchesTest do
         event: "contact_offer"
       )
 
-      assert [%Match{id: ^match_id, expiration_date: nil}] = Matches.list_matches(u1_id)
-      assert [%Match{id: ^match_id, expiration_date: nil}] = Matches.list_matches(u2_id)
+      assert [%Match{id: ^match_id, expiration_date: nil}] =
+               Matches.list_matches(u1_id, default_location())
+
+      assert [%Match{id: ^match_id, expiration_date: nil}] =
+               Matches.list_matches(u2_id, default_location())
     end
 
     test "matches with contact clicks don't have expiration date", ctx do
@@ -162,8 +169,11 @@ defmodule T.MatchesTest do
         event: "contact_click"
       )
 
-      assert [%Match{id: ^match_id, expiration_date: nil}] = Matches.list_matches(u1_id)
-      assert [%Match{id: ^match_id, expiration_date: nil}] = Matches.list_matches(u2_id)
+      assert [%Match{id: ^match_id, expiration_date: nil}] =
+               Matches.list_matches(u1_id, default_location())
+
+      assert [%Match{id: ^match_id, expiration_date: nil}] =
+               Matches.list_matches(u2_id, default_location())
     end
 
     test "matches have expiration date = inserted_at + 24h", ctx do
@@ -176,10 +186,10 @@ defmodule T.MatchesTest do
         inserted_at |> DateTime.from_naive!("Etc/UTC") |> DateTime.add(_1_day = 1 * 24 * 3600)
 
       assert [%Match{id: ^match_id, expiration_date: ^expected_expiration_date}] =
-               Matches.list_matches(u1_id)
+               Matches.list_matches(u1_id, default_location())
 
       assert [%Match{id: ^match_id, expiration_date: ^expected_expiration_date}] =
-               Matches.list_matches(u2_id)
+               Matches.list_matches(u2_id, default_location())
     end
 
     test "with seen matches", ctx do
@@ -188,18 +198,23 @@ defmodule T.MatchesTest do
         match: %{id: match_id}
       } = ctx
 
-      assert [%Match{id: ^match_id, seen: false}] = Matches.list_matches(u1_id)
-      assert [%Match{id: ^match_id, seen: false}] = Matches.list_matches(u2_id)
+      assert [%Match{id: ^match_id, seen: false}] =
+               Matches.list_matches(u1_id, default_location())
+
+      assert [%Match{id: ^match_id, seen: false}] =
+               Matches.list_matches(u2_id, default_location())
 
       :ok = Matches.mark_match_seen(u1_id, match_id)
 
-      assert [%Match{id: ^match_id, seen: true}] = Matches.list_matches(u1_id)
-      assert [%Match{id: ^match_id, seen: false}] = Matches.list_matches(u2_id)
+      assert [%Match{id: ^match_id, seen: true}] = Matches.list_matches(u1_id, default_location())
+
+      assert [%Match{id: ^match_id, seen: false}] =
+               Matches.list_matches(u2_id, default_location())
 
       :ok = Matches.mark_match_seen(u2_id, match_id)
 
-      assert [%Match{id: ^match_id, seen: true}] = Matches.list_matches(u1_id)
-      assert [%Match{id: ^match_id, seen: true}] = Matches.list_matches(u2_id)
+      assert [%Match{id: ^match_id, seen: true}] = Matches.list_matches(u1_id, default_location())
+      assert [%Match{id: ^match_id, seen: true}] = Matches.list_matches(u2_id, default_location())
     end
   end
 

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -100,8 +100,12 @@ defmodule TWeb.FeedChannelTest do
       mate1 = onboarded_user(story: [], name: "mate-1", location: apple_location(), gender: "F")
       mate2 = onboarded_user(story: [], name: "mate-2", location: apple_location(), gender: "F")
 
-      assert {:ok, %{like: %Matches.Like{}}} = Matches.like_user(mate1.id, me.id)
-      assert {:ok, %{like: %Matches.Like{}}} = Matches.like_user(mate2.id, me.id)
+      assert {:ok, %{like: %Matches.Like{}}} =
+               Matches.like_user(mate1.id, me.id, default_location())
+
+      assert {:ok, %{like: %Matches.Like{}}} =
+               Matches.like_user(mate2.id, me.id, default_location())
+
       assert :ok = Matches.mark_like_seen(me.id, mate2.id)
 
       assert {:ok, reply, _socket} = join(socket, "feed:" <> me.id, %{"mode" => "normal"})
@@ -706,7 +710,7 @@ defmodule TWeb.FeedChannelTest do
       %{me: me, socket: socket, mate: mate} = ctx
 
       # mate likes us
-      {:ok, _} = Matches.like_user(mate.id, me.id)
+      {:ok, _} = Matches.like_user(mate.id, me.id, default_location())
 
       # we see mate's like
       ref = push(socket, "seen-like", %{"user_id" => mate.id})
@@ -730,7 +734,7 @@ defmodule TWeb.FeedChannelTest do
       ref = push(socket, "seen-match", %{"match_id" => match.id})
       assert_reply ref, :ok, _reply
 
-      assert [%Match{seen: true}] = Matches.list_matches(me.id)
+      assert [%Match{seen: true}] = Matches.list_matches(me.id, default_location())
     end
   end
 
@@ -1003,8 +1007,8 @@ defmodule TWeb.FeedChannelTest do
     end
 
     test "matched: private story becomes visible", %{me: me, stacy: stacy} do
-      Matches.like_user(me.id, stacy.id)
-      Matches.like_user(stacy.id, me.id)
+      Matches.like_user(me.id, stacy.id, default_location())
+      Matches.like_user(stacy.id, me.id, default_location())
 
       assert_push "matched", %{"match" => %{"profile" => %{story: [public, private]}}}
       assert Map.keys(public) == ["background", "labels", "size"]

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -70,7 +70,13 @@ defmodule TWeb.FeedChannelTest do
       assert matches == [
                %{
                  "id" => m3.id,
-                 "profile" => %{name: "mate-3", story: [], user_id: p3.id, gender: "M"},
+                 "profile" => %{
+                   name: "mate-3",
+                   story: [],
+                   user_id: p3.id,
+                   gender: "M",
+                   distance: 9510
+                 },
                  "inserted_at" => ~U[2021-09-30 12:16:07Z],
                  "expiration_date" => ~U[2021-10-01 12:16:07Z]
                },
@@ -680,7 +686,8 @@ defmodule TWeb.FeedChannelTest do
                    name: "Private Stacy",
                    story: story,
                    user_id: mate.id,
-                   gender: "F"
+                   gender: "F",
+                   distance: 9510
                  },
                  "expiration_date" => expiration_date,
                  "inserted_at" => inserted_at

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -108,7 +108,7 @@ defmodule TWeb.FeedChannelTest do
                      story: [],
                      user_id: mate1.id,
                      gender: "F",
-                     distance: nil
+                     distance: 9510
                    }
                  },
                  %{
@@ -117,7 +117,7 @@ defmodule TWeb.FeedChannelTest do
                      story: [],
                      user_id: mate2.id,
                      gender: "F",
-                     distance: nil
+                     distance: 9510
                    },
                    "seen" => true
                  }

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -610,7 +610,7 @@ defmodule TWeb.FeedChannelTest do
                  name: "Private Stacy",
                  story: story,
                  user_id: mate.id,
-                 distance: nil
+                 distance: 9510
                }
              }
 


### PR DESCRIPTION
Continuing #662 

Distance is not added to seen matches because it allows continuous tracking of the same people (location + boolean for whether user logged into Since lately)