### PR TITLE
add min_version to news, add "new contacts" news story

### DIFF
--- a/lib/t/news.ex
+++ b/lib/t/news.ex
@@ -13,6 +13,7 @@ defmodule T.News do
       %{
         id: 1,
         timestamp: ~U[2022-03-02 20:31:00Z],
+        version: "6.0.0",
         story: [
           %{
             "background" => %{"color" => "#111010"},
@@ -139,6 +140,7 @@ defmodule T.News do
       %{
         id: 2,
         timestamp: ~U[2022-03-23 08:16:00Z],
+        version: "6.1.0",
         story: [
           %{
             "background" => %{"color" => "#111010"},
@@ -181,6 +183,59 @@ defmodule T.News do
             "size" => [375, 667]
           }
         ]
+      },
+      %{
+        id: 3,
+        timestamp: ~U[2022-03-31 10:00:00Z],
+        version: "6.1.1",
+        story: [
+          %{
+            "background" => %{"color" => "#111010"},
+            "labels" => [
+              %{
+                "value" => dgettext("news", "Привет! 👋"),
+                "position" => [24.0, 80.0],
+                "background_fill" => "#F97EB9"
+              },
+              %{
+                "value" => dgettext("news", "Мы добавили\nновые контакты:"),
+                "position" => [24.0, 148.0],
+                "background_fill" => "#F97EB9"
+              },
+              %{
+                "position" => [24.0, 238.0],
+                "answer" => "getsinceapp",
+                "question" => "messenger"
+              },
+              %{
+                "position" => [24.0, 306.0],
+                "answer" => "kindly@getsince.app",
+                "question" => "imessage"
+              },
+              %{
+                "position" => [24.0, 374.0],
+                "answer" => "since_app",
+                "question" => "twitter"
+              },
+              %{
+                "position" => [24.0, 442.0],
+                "answer" => "getsince",
+                "question" => "snapchat"
+              },
+              %{
+                "position" => [24.0, 510.0],
+                "answer" => "+11234567890",
+                "question" => "signal"
+              },
+              %{
+                "value" => dgettext("news", "Общайтесь там, где удобно ✌️"),
+                "position" => [24.0, 578.0],
+                "background_fill" => "#F97EB9"
+              }
+            ],
+            "size" => [375, 667]
+          }
+        ]
       }
     ]
   end
@@ -189,8 +244,8 @@ defmodule T.News do
     List.last(news()).id
   end
 
-  @spec list_news(Ecto.Bigflake.UUID.t()) :: [%{id: pos_integer(), story: [map]}]
-  def list_news(user_id) do
+  @spec list_news(Ecto.Bigflake.UUID.t(), Version.t()) :: [%{id: pos_integer(), story: [map]}]
+  def list_news(user_id, version) do
     last_seen_id = last_seen_id(user_id) || 0
     user_inserted_at = datetime(user_id)
 
@@ -198,6 +253,12 @@ defmodule T.News do
     |> Enum.filter(fn news_story ->
       case DateTime.compare(news_story.timestamp, user_inserted_at) do
         :lt -> false
+        _ -> true
+      end
+    end)
+    |> Enum.filter(fn news_story ->
+      case Version.compare(news_story.version, version) do
+        :gt -> false
         _ -> true
       end
     end)

--- a/lib/t/news.ex
+++ b/lib/t/news.ex
@@ -224,7 +224,7 @@ defmodule T.News do
               },
               %{
                 "position" => [24.0, 510.0],
-                "answer" => "+11234567890",
+                "answer" => "+541176148981",
                 "question" => "signal"
               },
               %{
@@ -251,16 +251,10 @@ defmodule T.News do
 
     Enum.filter(news(), fn news_story -> news_story.id > last_seen_id end)
     |> Enum.filter(fn news_story ->
-      case DateTime.compare(news_story.timestamp, user_inserted_at) do
-        :lt -> false
-        _ -> true
-      end
+      DateTime.compare(user_inserted_at, news_story.timestamp) == :lt
     end)
     |> Enum.filter(fn news_story ->
-      case Version.compare(news_story.version, version) do
-        :gt -> false
-        _ -> true
-      end
+      Version.compare(version, news_story.version) in [:eq, :gt]
     end)
   end
 

--- a/lib/t_web/channels/feed_channel.ex
+++ b/lib/t_web/channels/feed_channel.ex
@@ -42,7 +42,7 @@ defmodule TWeb.FeedChannel do
 
     news =
       user_id
-      |> News.list_news()
+      |> News.list_news(version)
       |> render_news(version, screen_width)
 
     todos =

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -98,76 +98,76 @@ msgid "must be equal to %{number}"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:363
+#: lib/t/accounts/profile.ex:369
 msgid "%{label} can't be blank"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:329
+#: lib/t/accounts/profile.ex:335
 msgid "%{label} has invalid format"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:341
+#: lib/t/accounts/profile.ex:347
 msgid "%{label} should be at least %{count} character(s)"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:352
+#: lib/t/accounts/profile.ex:358
 msgid "%{label} should be at most %{count} character(s)"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:298
+#: lib/t/accounts/profile.ex:300
 msgid "email address"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:190
+#: lib/t/accounts/profile.ex:188
 msgid "instagram username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:288
+#: lib/t/accounts/profile.ex:290
 msgid "phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:180
+#: lib/t/accounts/profile.ex:178
 msgid "telegram username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:247
+#: lib/t/accounts/profile.ex:245
 msgid "whatsapp phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:269
+#: lib/t/accounts/profile.ex:267
 msgid "imessage email address"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:276
+#: lib/t/accounts/profile.ex:278
 msgid "imessage phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:218
+#: lib/t/accounts/profile.ex:216
 msgid "messenger username"
 msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
-#: lib/t/accounts/profile.ex:257
+#: lib/t/accounts/profile.ex:255
 msgid "signal phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:204
+#: lib/t/accounts/profile.ex:202
 msgid "snapchat username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:232
+#: lib/t/accounts/profile.ex:230
 msgid "twitter username"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/news.po
+++ b/priv/gettext/en/LC_MESSAGES/news.po
@@ -12,97 +12,108 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:66
+#: lib/t/news.ex:67
 msgid "Вот наши, нажми 👇"
 msgstr "Here are ours, click 👇"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:115
+#: lib/t/news.ex:116
 msgid "Выглядит вот так 👉"
 msgstr "It looks like this 👉"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:62
+#: lib/t/news.ex:63
 msgid "Добавляй контакты\nв свою историю."
 msgstr "Add contacts\nto your story."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:31
+#: lib/t/news.ex:32
 msgid "Мы убрали аудио-дэйты\nи голосовые сообщения."
 msgstr "We removed audio dates\nand voice messages."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:107
+#: lib/t/news.ex:108
 msgid "На нее можно поместить\nсвой контакт и что-то\nболее личное про тебя."
 msgstr "You can place\nyour contact and something\nmore personal about you."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:92
+#: lib/t/news.ex:93
 msgid "Новые\nприватные страницы 👀"
 msgstr "New\nprivate pages 👀"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:42
+#: lib/t/news.ex:43
 msgid "Общайся с мэтчами,\nгде тебе удобно."
 msgstr "Talk to your matches\nwherever convenient."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:47
+#: lib/t/news.ex:48
 msgid "Подробности 👉"
 msgstr "Details 👉"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:131
+#: lib/t/news.ex:132
 msgid "Попробуй новый Since ✨"
 msgstr "Try new Since ✨"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:58
+#: lib/t/news.ex:59
 msgid "Представляем\nстикеры-контакты 🔥"
 msgstr "Introducing\ncontact stickers 🔥"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:21
-#: lib/t/news.ex:147
+#: lib/t/news.ex:22
+#: lib/t/news.ex:149
+#: lib/t/news.ex:196
 msgid "Привет! 👋"
 msgstr "Hi! 👋"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:98
+#: lib/t/news.ex:99
 msgid "Создай приватную страницу,\nона будет видна только\nтвоим мэтчам."
 msgstr "Create a private page,\nonly your matches\nwould see it."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:37
+#: lib/t/news.ex:38
 msgid "Теперь контакты -\nединственный способ\nкоммуникации."
 msgstr "Now contacts\nare the only way\nto communicate."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:26
+#: lib/t/news.ex:27
 msgid "У нас важные новости."
 msgstr "We have important news."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:82
+#: lib/t/news.ex:83
 msgid "Это ещё не всё 👉"
 msgstr "That's not all 👉"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:158
+#: lib/t/news.ex:160
 msgid "Теперь в ленте показывается\nпримерное расстояние\nдо пользователя."
 msgstr "Feed now shows\nthe approximate distance\nto the user."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:176
+#: lib/t/news.ex:178
 msgid "Включить авто-локацию"
 msgstr "Enable auto location"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:152
+#: lib/t/news.ex:154
 msgid "Мы добавили\nавтоматическую локацию."
 msgstr "We added\nauto location."
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:167
+#: lib/t/news.ex:169
 msgid "Ты можешь включить\nавтоматическое определение\nлокации, чтобы она\nоставалась актуальной 👇"
 msgstr "You can enable\nauto detection of location\nso that it\nstays up-to-date 👇"
+
+#, elixir-autogen, elixir-format
+#: lib/t/news.ex:201
+msgid "Мы добавили\nновые контакты:"
+msgstr "We added\nnew contacts:"
+
+#, elixir-autogen, elixir-format
+#: lib/t/news.ex:231
+msgid "Общайтесь там, где удобно ✌️"
+msgstr "Connect where it's convenient ✌️"

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -95,76 +95,76 @@ msgid "must be equal to %{number}"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:363
+#: lib/t/accounts/profile.ex:369
 msgid "%{label} can't be blank"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:329
+#: lib/t/accounts/profile.ex:335
 msgid "%{label} has invalid format"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:341
+#: lib/t/accounts/profile.ex:347
 msgid "%{label} should be at least %{count} character(s)"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:352
+#: lib/t/accounts/profile.ex:358
 msgid "%{label} should be at most %{count} character(s)"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:298
+#: lib/t/accounts/profile.ex:300
 msgid "email address"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:190
+#: lib/t/accounts/profile.ex:188
 msgid "instagram username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:288
+#: lib/t/accounts/profile.ex:290
 msgid "phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:180
+#: lib/t/accounts/profile.ex:178
 msgid "telegram username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:247
+#: lib/t/accounts/profile.ex:245
 msgid "whatsapp phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:269
+#: lib/t/accounts/profile.ex:267
 msgid "imessage email address"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:276
+#: lib/t/accounts/profile.ex:278
 msgid "imessage phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:218
+#: lib/t/accounts/profile.ex:216
 msgid "messenger username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:257
+#: lib/t/accounts/profile.ex:255
 msgid "signal phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:204
+#: lib/t/accounts/profile.ex:202
 msgid "snapchat username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:232
+#: lib/t/accounts/profile.ex:230
 msgid "twitter username"
 msgstr ""

--- a/priv/gettext/news.pot
+++ b/priv/gettext/news.pot
@@ -11,97 +11,108 @@ msgid ""
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:66
+#: lib/t/news.ex:67
 msgid "Вот наши, нажми 👇"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:115
+#: lib/t/news.ex:116
 msgid "Выглядит вот так 👉"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:62
+#: lib/t/news.ex:63
 msgid "Добавляй контакты\nв свою историю."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:31
+#: lib/t/news.ex:32
 msgid "Мы убрали аудио-дэйты\nи голосовые сообщения."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:107
+#: lib/t/news.ex:108
 msgid "На нее можно поместить\nсвой контакт и что-то\nболее личное про тебя."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:92
+#: lib/t/news.ex:93
 msgid "Новые\nприватные страницы 👀"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:42
+#: lib/t/news.ex:43
 msgid "Общайся с мэтчами,\nгде тебе удобно."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:47
+#: lib/t/news.ex:48
 msgid "Подробности 👉"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:131
+#: lib/t/news.ex:132
 msgid "Попробуй новый Since ✨"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:58
+#: lib/t/news.ex:59
 msgid "Представляем\nстикеры-контакты 🔥"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:21
-#: lib/t/news.ex:147
+#: lib/t/news.ex:22
+#: lib/t/news.ex:149
+#: lib/t/news.ex:196
 msgid "Привет! 👋"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:98
+#: lib/t/news.ex:99
 msgid "Создай приватную страницу,\nона будет видна только\nтвоим мэтчам."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:37
+#: lib/t/news.ex:38
 msgid "Теперь контакты -\nединственный способ\nкоммуникации."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:26
+#: lib/t/news.ex:27
 msgid "У нас важные новости."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:82
+#: lib/t/news.ex:83
 msgid "Это ещё не всё 👉"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:158
+#: lib/t/news.ex:160
 msgid "Теперь в ленте показывается\nпримерное расстояние\nдо пользователя."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:176
+#: lib/t/news.ex:178
 msgid "Включить авто-локацию"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:152
+#: lib/t/news.ex:154
 msgid "Мы добавили\nавтоматическую локацию."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:167
+#: lib/t/news.ex:169
 msgid "Ты можешь включить\nавтоматическое определение\nлокации, чтобы она\nоставалась актуальной 👇"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/t/news.ex:201
+msgid "Мы добавили\nновые контакты:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/t/news.ex:231
+msgid "Общайтесь там, где удобно ✌️"
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/errors.po
+++ b/priv/gettext/ru/LC_MESSAGES/errors.po
@@ -94,76 +94,76 @@ msgid "must be equal to %{number}"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:363
+#: lib/t/accounts/profile.ex:369
 msgid "%{label} can't be blank"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:329
+#: lib/t/accounts/profile.ex:335
 msgid "%{label} has invalid format"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:341
+#: lib/t/accounts/profile.ex:347
 msgid "%{label} should be at least %{count} character(s)"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:352
+#: lib/t/accounts/profile.ex:358
 msgid "%{label} should be at most %{count} character(s)"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:298
+#: lib/t/accounts/profile.ex:300
 msgid "email address"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:190
+#: lib/t/accounts/profile.ex:188
 msgid "instagram username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:288
+#: lib/t/accounts/profile.ex:290
 msgid "phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:180
+#: lib/t/accounts/profile.ex:178
 msgid "telegram username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:247
+#: lib/t/accounts/profile.ex:245
 msgid "whatsapp phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:269
+#: lib/t/accounts/profile.ex:267
 msgid "imessage email address"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:276
+#: lib/t/accounts/profile.ex:278
 msgid "imessage phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:218
+#: lib/t/accounts/profile.ex:216
 msgid "messenger username"
 msgstr ""
 
 #, elixir-autogen, elixir-format, fuzzy
-#: lib/t/accounts/profile.ex:257
+#: lib/t/accounts/profile.ex:255
 msgid "signal phone number"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:204
+#: lib/t/accounts/profile.ex:202
 msgid "snapchat username"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/accounts/profile.ex:232
+#: lib/t/accounts/profile.ex:230
 msgid "twitter username"
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/news.po
+++ b/priv/gettext/ru/LC_MESSAGES/news.po
@@ -12,97 +12,108 @@ msgstr ""
 "Plural-Forms: nplurals=3\n"
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:66
+#: lib/t/news.ex:67
 msgid "Вот наши, нажми 👇"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:115
+#: lib/t/news.ex:116
 msgid "Выглядит вот так 👉"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:62
+#: lib/t/news.ex:63
 msgid "Добавляй контакты\nв свою историю."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:31
+#: lib/t/news.ex:32
 msgid "Мы убрали аудио-дэйты\nи голосовые сообщения."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:107
+#: lib/t/news.ex:108
 msgid "На нее можно поместить\nсвой контакт и что-то\nболее личное про тебя."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:92
+#: lib/t/news.ex:93
 msgid "Новые\nприватные страницы 👀"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:42
+#: lib/t/news.ex:43
 msgid "Общайся с мэтчами,\nгде тебе удобно."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:47
+#: lib/t/news.ex:48
 msgid "Подробности 👉"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:131
+#: lib/t/news.ex:132
 msgid "Попробуй новый Since ✨"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:58
+#: lib/t/news.ex:59
 msgid "Представляем\nстикеры-контакты 🔥"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:21
-#: lib/t/news.ex:147
+#: lib/t/news.ex:22
+#: lib/t/news.ex:149
+#: lib/t/news.ex:196
 msgid "Привет! 👋"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:98
+#: lib/t/news.ex:99
 msgid "Создай приватную страницу,\nона будет видна только\nтвоим мэтчам."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:37
+#: lib/t/news.ex:38
 msgid "Теперь контакты -\nединственный способ\nкоммуникации."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:26
+#: lib/t/news.ex:27
 msgid "У нас важные новости."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:82
+#: lib/t/news.ex:83
 msgid "Это ещё не всё 👉"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:158
+#: lib/t/news.ex:160
 msgid "Теперь в ленте показывается\nпримерное расстояние\nдо пользователя."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:176
+#: lib/t/news.ex:178
 msgid "Включить авто-локацию"
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:152
+#: lib/t/news.ex:154
 msgid "Мы добавили\nавтоматическую локацию."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/t/news.ex:167
+#: lib/t/news.ex:169
 msgid "Ты можешь включить\nавтоматическое определение\nлокации, чтобы она\nоставалась актуальной 👇"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/t/news.ex:201
+msgid "Мы добавили\nновые контакты:"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/t/news.ex:231
+msgid "Общайтесь там, где удобно ✌️"
 msgstr ""

--- a/test/t/news/news_test.exs
+++ b/test/t/news/news_test.exs
@@ -3,17 +3,26 @@ defmodule T.NewsTest do
 
   alias T.News
 
+  @previous_version "6.1.0"
+  @current_version "6.1.1"
+
   describe "list_news/1" do
     test "to old user" do
       old_uid = "0000017c-14c7-9745-0242-ac1100020000"
-      news = News.list_news(old_uid)
-      assert length(news) == 2
+      news = News.list_news(old_uid, @current_version)
+      assert length(news) == 3
     end
 
     test "to not so old user" do
       not_so_old_uid = "0000017f-b531-3203-0e40-1573d1920000"
-      news = News.list_news(not_so_old_uid)
-      assert length(news) == 1
+      news = News.list_news(not_so_old_uid, @current_version)
+      assert length(news) == 2
+    end
+
+    test "to users of previous version" do
+      old_uid = "0000017c-14c7-9745-0242-ac1100020000"
+      news = News.list_news(old_uid, @previous_version)
+      assert length(news) == 2
     end
   end
 end


### PR DESCRIPTION
min_version is added for items that cannot be rendered correctly in previous versions

e.g. new contacts will be rendered as `interests` stickers:
<img width="718" alt="image" src="https://user-images.githubusercontent.com/16062322/161141545-52bbe003-6eee-45fa-9903-d6ffbf46b01e.png">
which is worse than not showing them at all
