### PR TITLE
quick fix for rendering audio stickers in admin/profiles

### DIFF
--- a/lib/t_web/live/profile/index.ex
+++ b/lib/t_web/live/profile/index.ex
@@ -187,7 +187,7 @@ defmodule TWeb.ProfileLive.Index do
 
       ~H"""
       <div class="absolute font-medium text-white" style={@style}>
-        <.text_label text={@label["value"] || @label["answer"]} alignment={@alignment} bg={@label["background_fill"]} />
+        <.text_label text={@label["value"] || @label["answer"] || @label["question"]} alignment={@alignment} bg={@label["background_fill"]} />
       </div>
       """
     end


### PR DESCRIPTION
issue: https://sentry.io/organizations/since-kindly/issues/3197757290/?project=5972006&query=is%3Aunresolved&statsPeriod=14d

proper fixing will require adding audio playback or at least a link to  audio_url https://github.com/getsince/test3/issues/698