### PR TITLE
add Spotify token fetch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,6 @@ jobs:
 
       - name: Run tests
         env:
-          test: ${{ secrets.test }}
+          SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
         run: mix test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,4 @@ jobs:
         env:
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
-        run: mix test
+        run: mix test --include integration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,6 @@ jobs:
         run: MIX_ENV=test mix compile --warnings-as-errors
 
       - name: Run tests
+        env:
+          test: ${{ secrets.test }}
         run: mix test

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -129,6 +129,10 @@ if config_env() == :prod and not smoke? do
     media_bucket: System.fetch_env!("AWS_S3_BUCKET_MEDIA"),
     media_cdn: System.fetch_env!("MEDIA_CDN")
 
+  config :t, T.Spotify,
+    client_id: System.fetch_env!("SPOTIFY_CLIENT_ID"),
+    client_secret: System.fetch_env!("SPOTIFY_CLIENT_SECRET")
+
   config :t, T.Events,
     buffers: [:seen_buffer, :like_buffer, :contact_buffer],
     bucket: System.fetch_env!("AWS_S3_BUCKET_EVENTS")
@@ -227,6 +231,10 @@ if config_env() == :dev do
     media_bucket: System.fetch_env!("AWS_S3_BUCKET_MEDIA"),
     media_cdn: System.fetch_env!("MEDIA_CDN")
 
+  config :t, T.Spotify,
+    client_id: System.fetch_env!("SPOTIFY_CLIENT_ID"),
+    client_secret: System.fetch_env!("SPOTIFY_CLIENT_SECRET")
+
   config :t, T.Events, buffers: false, bucket: System.get_env("AWS_S3_BUCKET_EVENTS")
   config :t, T.Media.Static, disabled?: !!System.get_env("DISABLE_MEDIA")
   config :t, T.Periodics, disabled?: !!System.get_env("DISABLE_PERIODICS")
@@ -264,6 +272,10 @@ if config_env() == :test do
     media_bucket: "pretend-this-is-media",
     static_cdn: "https://d4321.cloudfront.net",
     media_cdn: "https://d6666.cloudfront.net"
+
+  config :t, T.Spotify,
+    client_id: "1234",
+    client_secret: "5678"
 
   config :ex_aws,
     access_key_id: "AWS_ACCESS_KEY_ID",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -274,8 +274,8 @@ if config_env() == :test do
     media_cdn: "https://d6666.cloudfront.net"
 
   config :t, T.Spotify,
-    client_id: "1234",
-    client_secret: "5678"
+    client_id: System.fetch_env!("SPOTIFY_CLIENT_ID"),
+    client_secret: System.fetch_env!("SPOTIFY_CLIENT_SECRET")
 
   config :ex_aws,
     access_key_id: "AWS_ACCESS_KEY_ID",
@@ -292,7 +292,7 @@ if config_env() == :test do
 
   config :t, T.PushNotifications.APNS, default_topic: "app.topic"
   config :t, T.Periodics, disabled?: true
-  config :t, Finch, disabled?: true
+  config :t, Finch, disabled?: false
 
   # TODO
   config :t, primary_prefix: "nohost"

--- a/lib/t/application.ex
+++ b/lib/t/application.ex
@@ -12,7 +12,7 @@ defmodule T.Application do
         {Task.Supervisor, name: T.TaskSupervisor},
         maybe_events(),
         APNS.Token,
-        unless_disabled(T.Spotify),
+        T.Spotify,
         maybe_finch(),
         maybe_cluster(),
         {Phoenix.PubSub, name: T.PubSub},

--- a/lib/t/application.ex
+++ b/lib/t/application.ex
@@ -12,6 +12,7 @@ defmodule T.Application do
         {Task.Supervisor, name: T.TaskSupervisor},
         maybe_events(),
         APNS.Token,
+        unless_disabled(T.Spotify),
         maybe_finch(),
         maybe_cluster(),
         {Phoenix.PubSub, name: T.PubSub},

--- a/lib/t/spotify.ex
+++ b/lib/t/spotify.ex
@@ -1,0 +1,40 @@
+defmodule T.Spotify do
+  @moduledoc "spotify api client"
+
+  @spotify_token_url "https://accounts.spotify.com/api/token"
+
+  def token do
+    config = Application.get_env(:t, __MODULE__)
+    token(config)
+  end
+
+  # TODO cache?
+  def token(config) do
+    client_id = Keyword.fetch!(config, :client_id)
+    client_secret = Keyword.fetch!(config, :client_secret)
+
+    auth_key = Base.encode64(client_id <> ":" <> client_secret)
+
+    headers = [
+      {"authorization", "basic " <> auth_key},
+      {"content-type", "application/x-www-form-urlencoded"}
+    ]
+
+    body = "grant_type=client_credentials"
+
+    req = Finch.build(:post, @spotify_token_url, headers, body)
+
+    case Finch.request(req, T.Finch, receive_timeout: 5000) do
+      {:ok, %Finch.Response{status: _status, body: body, headers: _headers}} ->
+        case Jason.decode(body) do
+          {:ok, %{"access_token" => token}} -> {:ok, %{token: token}}
+          {:ok, %{"error" => error}} -> {:error, %{reason: error}}
+          {:ok, body} -> {:error, %{reason: body}}
+          {:error, error} -> {:error, %{reason: error}}
+        end
+
+      {:error, reason} ->
+        {:error, %{reason: reason}}
+    end
+  end
+end

--- a/lib/t/spotify.ex
+++ b/lib/t/spotify.ex
@@ -83,12 +83,16 @@ defmodule T.Spotify do
           {:ok, %{"access_token" => token, "expires_in" => expires_in}} ->
             {token, now + expires_in}
 
-          json ->
-            Sentry.capture_message("failed to decode spotify token", extra: json)
+          {:ok, extra} ->
+            Sentry.capture_message("failed to decode spotify token", extra: extra)
+            nil
+
+          {:error, extra} ->
+            Sentry.capture_message("failed to decode spotify token", extra: extra)
             nil
         end
 
-      reply ->
+      {:error, reply} ->
         Sentry.capture_message("failed to receive spotify token", extra: reply)
         nil
     end

--- a/lib/t_web/channels/profile_channel.ex
+++ b/lib/t_web/channels/profile_channel.ex
@@ -71,7 +71,6 @@ defmodule TWeb.ProfileChannel do
     {:reply, reply, socket}
   end
 
-  # TODO refresh after one hour
   def handle_in("get-spotify-token", _params, socket) do
     {:reply, Spotify.current_token(), socket}
   end

--- a/lib/t_web/channels/profile_channel.ex
+++ b/lib/t_web/channels/profile_channel.ex
@@ -71,7 +71,7 @@ defmodule TWeb.ProfileChannel do
     {:reply, reply, socket}
   end
 
-  # TODO refresh after two hours
+  # TODO refresh after one hour
   def handle_in("get-spotify-token", _params, socket) do
     token = socket.assigns[:spotify_token] || Spotify.token()
     socket = assign(socket, spotify_token: token)

--- a/lib/t_web/channels/profile_channel.ex
+++ b/lib/t_web/channels/profile_channel.ex
@@ -1,7 +1,7 @@
 defmodule TWeb.ProfileChannel do
   use TWeb, :channel
   alias T.Accounts.Profile
-  alias T.{Accounts, Media}
+  alias T.{Accounts, Media, Spotify}
   alias TWeb.{ErrorView, ProfileView}
 
   @impl true
@@ -69,6 +69,13 @@ defmodule TWeb.ProfileChannel do
       end
 
     {:reply, reply, socket}
+  end
+
+  # TODO refresh after two hours
+  def handle_in("get-spotify-token", _params, socket) do
+    token = socket.assigns[:spotify_token] || Spotify.token()
+    socket = assign(socket, spotify_token: token)
+    {:reply, {:ok, %{token: token}}, socket}
   end
 
   # TODO remove

--- a/lib/t_web/channels/profile_channel.ex
+++ b/lib/t_web/channels/profile_channel.ex
@@ -73,9 +73,7 @@ defmodule TWeb.ProfileChannel do
 
   # TODO refresh after one hour
   def handle_in("get-spotify-token", _params, socket) do
-    token = socket.assigns[:spotify_token] || Spotify.token()
-    socket = assign(socket, spotify_token: token)
-    {:reply, {:ok, %{token: token}}, socket}
+    {:reply, Spotify.current_token(), socket}
   end
 
   # TODO remove

--- a/test/t/apis/spotify_test.exs
+++ b/test/t/apis/spotify_test.exs
@@ -1,0 +1,10 @@
+defmodule T.SpotifyTest do
+  use T.DataCase, async: true
+  alias T.Spotify
+
+  describe "current_token" do
+    test "fetches a token from spotify" do
+      assert {:ok, _token} = Spotify.current_token()
+    end
+  end
+end

--- a/test/t/apis/spotify_test.exs
+++ b/test/t/apis/spotify_test.exs
@@ -1,8 +1,9 @@
 defmodule T.SpotifyTest do
-  use T.DataCase, async: true
+  use ExUnit.Case, async: true
   alias T.Spotify
 
   describe "current_token" do
+    @tag :integration
     test "fetches a token from spotify" do
       assert {:ok, _token} = Spotify.current_token()
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 Application.put_env(:ex_unit, :assert_receive_timeout, 1000)
+ExUnit.configure(exclude: [:integration])
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(T.Repo, :manual)


### PR DESCRIPTION
enables users to make basic API requests which do not requite user auth (search for tracks)